### PR TITLE
GetDefaultValue - return null when type is void

### DIFF
--- a/reflection/src/AspectCore.Extensions.Reflection/Extensions/TypeExtensions.cs
+++ b/reflection/src/AspectCore.Extensions.Reflection/Extensions/TypeExtensions.cs
@@ -36,6 +36,12 @@ namespace AspectCore.Extensions.Reflection
             {
                 throw new ArgumentNullException(nameof(typeInfo));
             }
+
+            if (typeInfo.AsType() == typeof(void))
+            {
+                return null;
+            }
+
             switch (Type.GetTypeCode(typeInfo.AsType()))
             {
                 case TypeCode.Object:


### PR DESCRIPTION
Fixing error:
```
Exception has been thrown by the aspect of an invocation. ---> Cannot dynamically create an instance of System.Void..Cannot dynamically create an instance of System.Void.
Failed method
AspectCore.Extensions.Reflection.TypeExtensions.GetDefaultValue
```
Reproduction: call _Break()_ (at AspectContext) within interceptor on a service which returning _void_.