### PR TITLE
Intercept async method

### DIFF
--- a/core/test/AspectCore.Tests/Injector/AsyncBlockTest.cs
+++ b/core/test/AspectCore.Tests/Injector/AsyncBlockTest.cs
@@ -16,10 +16,57 @@ namespace AspectCore.Tests.Injector
         }
     }
 
+    public class InvokeEndIntercept : AbstractInterceptorAttribute
+    {
+        public override Task Invoke(AspectContext context, AspectDelegate next)
+        {
+            var startTime = DateTime.Now;
+            Console.WriteLine($"{startTime}:start");
+            var task = next(context);
+
+            if (context.ReturnValue is Task resultTask)
+            {
+                resultTask.ContinueWith((o) =>
+                {
+                    // 被代理的方法已经执行
+                    var startTimeInner = startTime;
+                    var endTime = DateTime.Now;
+                    Console.WriteLine($"{endTime}:end");
+                });
+            }
+            else
+            {
+                var endTime = DateTime.Now;
+                Console.WriteLine($"{endTime}:end");
+            }
+            return task;
+        }
+    }
+
+
+    public class InvokeEndFailtIntercept : AbstractInterceptorAttribute
+    {
+        public async override Task Invoke(AspectContext context, AspectDelegate next)
+        {
+            var startTime = DateTime.Now;
+            Console.WriteLine($"{startTime}:start");
+            await next(context);
+            //未等待被代理的方法执行
+            var endTime = DateTime.Now;
+            Console.WriteLine($"{endTime}:end");
+        }
+    }
+
 
     public interface IService1
     {
         Task<string> GetValue(string val);
+
+        Task<string> GetValue2(string val);
+
+        Task<string> GetValue3(string val);
+
+
     }
 
     public class Service1 : IService1
@@ -30,13 +77,29 @@ namespace AspectCore.Tests.Injector
             await Task.Delay(3000);
             return val;
         }
+
+
+        [InvokeEndIntercept]
+        public async Task<string> GetValue2(string val)
+        {
+            await Task.Delay(4000);
+            return val;
+        }
+
+
+        [InvokeEndFailtIntercept]
+        public async Task<string> GetValue3(string val)
+        {
+            await Task.Delay(3000);
+            return val;
+        }
     }
 
     public class AsyncBlockTest : InjectorTestBase
     {
 
         [Fact]
-        public void AsyncBlock()
+        public async void AsyncBlock()
         {
             var builder = new ProxyGeneratorBuilder();
             builder.Configure(_ => { });
@@ -53,6 +116,13 @@ namespace AspectCore.Tests.Injector
             Assert.True((endTime - startTime).TotalSeconds < 2);
             Console.WriteLine($"{endTime}:should return immediately");
             Console.WriteLine($"{DateTime.Now}:{val.Result}");
+
+            var val2 = await proxy.GetValue2("le2");
+            Console.WriteLine($"{val2}");
+
+
+            var val3 = await proxy.GetValue3("le3");
+            Console.WriteLine($"{val3}");
         }
     }
 }


### PR DESCRIPTION
移除掉 task.GetAwaiter().GetResult() ，需要使用 
```cs
 if (context.ReturnValue is Task resultTask)
            {
                resultTask.ContinueWith((o) =>
                {
                }
            }
```
才能正确的等待被代理的方法执行完，进一步做处理。