### PR TITLE
一处笔误，还有关于在Invoke方法内包含异步代码时，Interceptor不会await这些代码

### DIFF
--- a/core/src/AspectCore.Core/DynamicProxy/AspectActivator.cs
+++ b/core/src/AspectCore.Core/DynamicProxy/AspectActivator.cs
@@ -1,4 +1,5 @@
-﻿ using System;
+﻿using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using AspectCore.Utils;
 
@@ -22,14 +23,24 @@ namespace AspectCore.DynamicProxy
             try
             {
                 var aspectBuilder = _aspectBuilderFactory.Create(context);
-                var invoke = aspectBuilder.Build()(context);
-                if (invoke.IsFaulted)
+                var task = aspectBuilder.Build()(context);
+                if (task.IsFaulted)
+                    throw context.InvocationException(task.Exception);
+                else if (!task.IsCompleted)
                 {
-                    var innerException = invoke.Exception?.InnerException;
-                    throw context.InvocationException(innerException);
+                    // if you get here, 
+                    // it means there are some async codes, which are still running, 
+                    // in the context of a sync method.
+                    // I don't know how to do to run the codes properly
+                    // without causing potential deadlocks.
+                    // Just Wait here.
+                    task.Wait();
                 }
-            
                 return (TResult)context.ReturnValue;
+            }
+            catch (Exception ex)
+            {
+                throw context.InvocationException(ex);
             }
             finally
             {
@@ -37,36 +48,32 @@ namespace AspectCore.DynamicProxy
             }
         }
 
-        public Task<TResult> InvokeTask<TResult>(AspectActivatorContext activatorContext)
+        public async Task<TResult> InvokeTask<TResult>(AspectActivatorContext activatorContext)
         {
             var context = _aspectContextFactory.CreateContext(activatorContext);
             try
             {
                 var aspectBuilder = _aspectBuilderFactory.Create(context);
-                var invoke = aspectBuilder.Build()(context);
-                if (invoke.IsFaulted)
-                {
-                    var innerException = invoke.Exception?.InnerException;
-                    throw context.InvocationException(innerException);
-                }
-              
+                await aspectBuilder.Build()(context);
                 var result = context.ReturnValue;
-                if (result == null)
+                if (result is Task<TResult> taskWithResult)
                 {
-                    return default(Task<TResult>);
-                }
-                else if (result is Task<TResult> resultTask)
-                {
-                    return resultTask;
+                    return await taskWithResult;
                 }
                 else if (result is Task task)
                 {
-                    return TaskUtils<TResult>.CompletedTask;
+                    await task;
+                    return default(TResult);
                 }
                 else
                 {
-                    throw context.InvocationException(new InvalidCastException($"Unable to cast object of type '{result.GetType()}' to type '{typeof(Task<TResult>)}'."));
+                    throw context.InvocationException(new InvalidCastException(
+                        $"Unable to cast object of type '{result.GetType()}' to type '{typeof(Task<TResult>)}'."));
                 }
+            }
+            catch (Exception ex)
+            {
+                throw context.InvocationException(ex);
             }
             finally
             {
@@ -74,20 +81,18 @@ namespace AspectCore.DynamicProxy
             }
         }
 
-        public ValueTask<TResult> InvokeValueTask<TResult>(AspectActivatorContext activatorContext)
+        public async ValueTask<TResult> InvokeValueTask<TResult>(AspectActivatorContext activatorContext)
         {
             var context = _aspectContextFactory.CreateContext(activatorContext);
             try
             {
                 var aspectBuilder = _aspectBuilderFactory.Create(context);
-                var invoke = aspectBuilder.Build()(context);
-                if (invoke.IsFaulted)
-                {
-                    var innerException = invoke.Exception?.InnerException;
-                    throw context.InvocationException(innerException);
-                }
-              
-                return (ValueTask<TResult>)context.ReturnValue;
+                await aspectBuilder.Build()(context);
+                return await (ValueTask<TResult>)context.ReturnValue;
+            }
+            catch (Exception ex)
+            {
+                throw context.InvocationException(ex);
             }
             finally
             {

--- a/core/src/AspectCore.Core/DynamicProxy/AspectActivator.cs
+++ b/core/src/AspectCore.Core/DynamicProxy/AspectActivator.cs
@@ -28,13 +28,7 @@ namespace AspectCore.DynamicProxy
                     throw context.InvocationException(task.Exception);
                 else if (!task.IsCompleted)
                 {
-                    // if you get here, 
-                    // it means there are some async codes, which are still running, 
-                    // in the context of a sync method.
-                    // I don't know how to do to run the codes properly
-                    // without causing potential deadlocks.
-                    // Just Wait here.
-                    task.Wait();
+                    task.GetAwaiter().GetResult();
                 }
                 return (TResult)context.ReturnValue;
             }

--- a/core/src/AspectCore.Core/Utils/ReflectionUtils.cs
+++ b/core/src/AspectCore.Core/Utils/ReflectionUtils.cs
@@ -147,7 +147,8 @@ namespace AspectCore.DynamicProxy
             {
                 throw new ArgumentNullException(nameof(methodInfo));
             }
-            return typeof(Task).GetTypeInfo().IsTaskWithResult();
+            var returnType = methodInfo.ReturnType.GetTypeInfo();
+            return returnType.IsTaskWithResult();
         }
 
         public static bool IsReturnValueTask(this MethodInfo methodInfo)

--- a/extras/test/AspectCore.Extensions.Windsor.Test/AsyncInterceptorTests.cs
+++ b/extras/test/AspectCore.Extensions.Windsor.Test/AsyncInterceptorTests.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using AspectCore.DynamicProxy;
+using AspectCore.Extensions.Windsor.Test.Fakes;
+using Castle.Core;
+using Castle.MicroKernel.Registration;
+using Castle.Windsor;
+using Xunit;
+
+namespace AspectCore.Extensions.Windsor.Test
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public class AsyncIncreamentAttribute : AbstractInterceptorAttribute
+    {
+        public override async Task Invoke(AspectContext context, AspectDelegate next)
+        {
+            await context.Invoke(next);
+            await Task.Delay(1000); // 此处模拟一个真.异步方法，用于测试线程上下文切换
+
+            if (context.ReturnValue is Task<int> task)
+            {
+                var result = await task;
+                context.ReturnValue = Task.FromResult(result + 1);
+            }
+            else if (context.ReturnValue is ValueTask<int> valueTask)
+            {
+                var result = await valueTask;
+                context.ReturnValue = new ValueTask<int>(result + 1);
+            }
+            else if (context.ReturnValue is int result)
+            {
+                context.ReturnValue = result + 1;
+            }
+        }
+    }
+
+    public class AsyncService
+    {
+        [AsyncIncreament]
+        public virtual void DonotGet(int num)
+        {
+        }
+
+        [AsyncIncreament]
+        public virtual Task DonotGetAsync(int num)
+        {
+            return Task.CompletedTask;
+        }
+
+        [AsyncIncreament]
+        public virtual int Get(int num)
+        {
+            return num;
+        }
+
+        [AsyncIncreament]
+        public virtual async Task<int> GetAsyncWithTask(int num)
+        {
+            await Task.Delay(1000);
+            return num;
+        }
+
+        [AsyncIncreament]
+        public virtual async ValueTask<int> GetAsyncWithValueTask(int num)
+        {
+            await Task.Delay(1000);
+            return num;
+        }
+    }
+
+    public class AsyncMethodTests
+    {
+        public static IEnumerable<object[]> GetNumbers()
+        {
+            yield return new object[] { -100 };
+            yield return new object[] { -1 };
+            yield return new object[] { 0 };
+            yield return new object[] { 1 };
+            yield return new object[] { 10 };
+            yield return new object[] { 100 };
+        }
+
+        private static IWindsorContainer CreateWindsorContainer()
+        {
+            return new WindsorContainer()
+                .AddAspectCoreFacility()
+                .Register(Component.For<AsyncService>().LifestyleTransient());
+        }
+
+        [Theory]
+        [MemberData(nameof(GetNumbers))]
+        public void TestIncreamentForVoid(int input)
+        {
+            var container = CreateWindsorContainer();
+            var service = container.Resolve<AsyncService>();
+            service.DonotGet(input);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetNumbers))]
+        public async Task TestIncreamentForTask(int input)
+        {
+            var container = CreateWindsorContainer();
+            var service = container.Resolve<AsyncService>();
+            await service.DonotGetAsync(input);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetNumbers))]
+        public void TestIncreamentForResult(int input)
+        {
+            var container = CreateWindsorContainer();
+            var service = container.Resolve<AsyncService>();
+            Assert.Equal(input + 1, service.Get(input));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetNumbers))]
+        public async Task TestIncreamentForTaskResult(int input)
+        {
+            var container = CreateWindsorContainer();
+            var service = container.Resolve<AsyncService>();
+            Assert.Equal(input + 1, await service.GetAsyncWithTask(input));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetNumbers))]
+        public async Task TestIncreamentForValueTaskResult(int input)
+        {
+            var container = CreateWindsorContainer();
+            var service = container.Resolve<AsyncService>();
+            Assert.Equal(input + 1, await service.GetAsyncWithValueTask(input));
+        }
+    }
+}

--- a/extras/test/AspectCore.Extensions.Windsor.Test/Fakes/CacheService.cs
+++ b/extras/test/AspectCore.Extensions.Windsor.Test/Fakes/CacheService.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace AspectCore.Extensions.Windsor.Test.Fakes
 {
-    public class Service : IService
+    public class CacheService : ICacheService
     {
         public Model Get(int id)
         {

--- a/extras/test/AspectCore.Extensions.Windsor.Test/Fakes/Controller.cs
+++ b/extras/test/AspectCore.Extensions.Windsor.Test/Fakes/Controller.cs
@@ -2,9 +2,9 @@
 {
     public class Controller : IController
     {
-        public IService Service { get; }
+        public ICacheService Service { get; }
 
-        public Controller(IService service)
+        public Controller(ICacheService service)
         {
             Service = service;
         }

--- a/extras/test/AspectCore.Extensions.Windsor.Test/Fakes/ICacheService.cs
+++ b/extras/test/AspectCore.Extensions.Windsor.Test/Fakes/ICacheService.cs
@@ -2,7 +2,7 @@
 
 namespace AspectCore.Extensions.Windsor.Test.Fakes
 {
-    public interface IService
+    public interface ICacheService
     {
         [CacheInterceptor]
         Model Get(int id);

--- a/extras/test/AspectCore.Extensions.Windsor.Test/Fakes/IController.cs
+++ b/extras/test/AspectCore.Extensions.Windsor.Test/Fakes/IController.cs
@@ -3,7 +3,7 @@
     [CacheInterceptor]
     public interface IController
     {
-        IService Service { get; }
+        ICacheService Service { get; }
         Model Execute();
     }
 }

--- a/extras/test/AspectCore.Extensions.Windsor.Test/RegistrationExtensionsTests.cs
+++ b/extras/test/AspectCore.Extensions.Windsor.Test/RegistrationExtensionsTests.cs
@@ -19,8 +19,8 @@ namespace AspectCore.Extensions.Windsor.Test
         public async Task AsProxy_Test()
         {
             var container = CreateWindsorContainer();
-            container.Register(Component.For<IService>().ImplementedBy<Service>().LifestyleTransient());
-            var proxyService = container.Resolve<IService>();
+            container.Register(Component.For<ICacheService>().ImplementedBy<CacheService>().LifestyleTransient());
+            var proxyService = container.Resolve<ICacheService>();
             Assert.Equal(proxyService.Get(1), proxyService.Get(1));
             Assert.Equal(await proxyService.GetAsync(2), await proxyService.GetAsync(2));
         }
@@ -29,10 +29,10 @@ namespace AspectCore.Extensions.Windsor.Test
         public void AsProxyWithParamter_Test()
         {
             var container = CreateWindsorContainer();
-            container.Register(Component.For<IService>().ImplementedBy<Service>().LifestyleTransient(),
+            container.Register(Component.For<ICacheService>().ImplementedBy<CacheService>().LifestyleTransient(),
                 Component.For<IController>().ImplementedBy<Controller>().LifestyleTransient());
 
-            var proxyService = container.Resolve<IService>();
+            var proxyService = container.Resolve<ICacheService>();
             Assert.Equal(proxyService.Get(1), proxyService.Get(1));
 
             var proxyController = container.Resolve<IController>();

--- a/extras/test/AspectCore.Extensions.Windsor.Test/ScopedServiceTests.cs
+++ b/extras/test/AspectCore.Extensions.Windsor.Test/ScopedServiceTests.cs
@@ -7,9 +7,9 @@ using Castle.MicroKernel.Registration;
 using Xunit;
 using AspectCore.Configuration;
 
-namespace AspectCore.Extension.Windsor.Test
+namespace AspectCore.Extensions.Windsor.Test
 {
-    public class UnitTest1
+    public class ScopedServiceTests
     {
         [Fact]
         public void Test1()


### PR DESCRIPTION
1.fix typo in ReflectionUtils.cs 
2.try to fix bugs for running async codes in the method "Invoke" of Interceptor.

举例：
有如下拦截器
```
    [AttributeUsage(AttributeTargets.Method)]
    public class AsyncIncreamentAttribute : AbstractInterceptorAttribute
    {
        public override async Task Invoke(AspectContext context, AspectDelegate next)
        {
            await context.Invoke(next);
            await Task.Delay(1000);  //这是一个会切换上下文的真.异步操作
            ............异步之后的代码......................
        }
    }
```
【异步之后的代码】不会在拦截器内执行，Invoke方法会执行到await Task.Delay(1000)就返回

具体可以参见AspectCore.Extensions.Windsor.Test这个测试项目里的AsyncInterceptorTests测试类
包含了几种情况的测试用例。

这个pr就是根据这些用例进行尝试修复。
所有测试用例已经通过，**但包含一个潜在的问题**
若被拦截方法是一个同步方法，拦截器内的异步代码的运行方式是task.wait()
我不知道会不会产生死锁
具体情况在AspectActivator类中注明
