### PR TITLE
主要解决aspectcore.windsor里的bug #105

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,9 @@ artifacts:
 - path: artifacts/packages/*.nupkg
 deploy:
 - provider: NuGet
-  server: https://www.myget.org/F/aspectcore/api/v2/package
+  server: https://www.myget.org/F/huoshan12345/api/v2/package
   api_key:
-    secure: jpjXYvzq6XOX2E5PnhKPRBK/DKVoZAQ6Ok1UmWI3BuWq6rdtrGJMUJem/GtR8+qG
+    secure: pVZ8cfaAD/kj48+EAc3tRs6ozE6O92CIWnwXVsSWfoYi9/j5w89K5BO5KYX17I1p
   skip_symbols: true
   artifact: /artifacts\/packages\/.+\.nupkg/
   on:

--- a/core/src/AspectCore.Core/DynamicProxy/AspectActivator.cs
+++ b/core/src/AspectCore.Core/DynamicProxy/AspectActivator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using AspectCore.Core.Utils;
 using AspectCore.Utils;
 
 namespace AspectCore.DynamicProxy
@@ -28,7 +29,9 @@ namespace AspectCore.DynamicProxy
                     throw context.InvocationException(task.Exception);
                 else if (!task.IsCompleted)
                 {
-                    task.GetAwaiter().GetResult();
+                    // try to avoid potential deadlocks.
+                    NoSyncContextScope.Run(task);
+                    // task.GetAwaiter().GetResult();
                 }
                 return (TResult)context.ReturnValue;
             }

--- a/core/src/AspectCore.Core/Utils/NoSyncContextScope.cs
+++ b/core/src/AspectCore.Core/Utils/NoSyncContextScope.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AspectCore.Core.Utils
+{
+    public static class NoSyncContextScope
+    {
+        // See: https://stackoverflow.com/questions/28305968/use-task-run-in-synchronous-method-to-avoid-deadlock-waiting-on-async-method
+        public static IDisposable Enter()
+        {
+            var context = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(null);
+            return new Disposable(context);
+        }
+
+        private struct Disposable : IDisposable
+        {
+            private readonly SynchronizationContext _synchronizationContext;
+
+            public Disposable(SynchronizationContext synchronizationContext)
+            {
+                _synchronizationContext = synchronizationContext;
+            }
+
+            public void Dispose() =>
+                SynchronizationContext.SetSynchronizationContext(_synchronizationContext);
+        }
+
+        public static void Run(Task task)
+        {
+            using (Enter())
+            {
+                task.GetAwaiter().GetResult();
+            }
+        }
+
+        public static T Run<T>(Task<T> task)
+        {
+            using (Enter())
+            {
+                return task.GetAwaiter().GetResult();
+            }
+        }
+    }
+}

--- a/extras/src/AspectCore.Extensions.Windsor/AspectCoreInterceptor.cs
+++ b/extras/src/AspectCore.Extensions.Windsor/AspectCoreInterceptor.cs
@@ -25,20 +25,21 @@ namespace AspectCore.Extensions.Windsor
 
         public void Intercept(IInvocation invocation)
         {
+            invocation.Proceed();
             if (!_aspectValidator.Validate(invocation.Method, true) && !_aspectValidator.Validate(invocation.MethodInvocationTarget, false))
             {
-                invocation.Proceed();
                 return;
             }
             if (invocation.Proxy == null)
             {
                 return;
             }
+
+            var returnValue = invocation.ReturnValue;
             var proxyTypeInfo = invocation.Proxy.GetType().GetTypeInfo();
             var builderFactory = new WindsorAspectBuilderFactory(_aspectBuilderFactory, ctx =>
             {
-                invocation.Proceed();
-                ctx.ReturnValue = invocation.ReturnValue;
+                ctx.ReturnValue = returnValue;
                 return Task.FromResult(0);
             });
             var proxyMethod = proxyTypeInfo.GetMethodBySignature(invocation.Method);

--- a/extras/test/AspectCore.Extensions.Windsor.Test/AspectCore.Extensions.Windsor.Test.csproj
+++ b/extras/test/AspectCore.Extensions.Windsor.Test/AspectCore.Extensions.Windsor.Test.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <RootNamespace>AspectCoreTest.Windsor</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/extras/test/AspectCore.Extensions.Windsor.Test/AsyncInterceptorTests.cs
+++ b/extras/test/AspectCore.Extensions.Windsor.Test/AsyncInterceptorTests.cs
@@ -15,7 +15,7 @@ namespace AspectCoreTest.Windsor
         public override async Task Invoke(AspectContext context, AspectDelegate next)
         {
             await context.Invoke(next);
-            await Task.Delay(1000); // 此处模拟一个真.异步方法，用于测试线程上下文切换
+            await Task.Delay(100); // 此处模拟一个真.异步方法，用于测试线程上下文切换
 
             if (context.ReturnValue is Task<int> task)
             {
@@ -56,14 +56,14 @@ namespace AspectCoreTest.Windsor
         [AsyncIncreament]
         public virtual async Task<int> GetAsyncWithTask(int num)
         {
-            await Task.Delay(1000);
+            await Task.Delay(100);
             return num;
         }
 
         [AsyncIncreament]
         public virtual async ValueTask<int> GetAsyncWithValueTask(int num)
         {
-            await Task.Delay(1000);
+            await Task.Delay(100);
             return num;
         }
     }

--- a/extras/test/AspectCore.Extensions.Windsor.Test/AsyncInterceptorTests.cs
+++ b/extras/test/AspectCore.Extensions.Windsor.Test/AsyncInterceptorTests.cs
@@ -1,15 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using AspectCore.DynamicProxy;
-using AspectCore.Extensions.Windsor.Test.Fakes;
-using Castle.Core;
+using AspectCore.Extensions.Windsor;
 using Castle.MicroKernel.Registration;
 using Castle.Windsor;
 using Xunit;
 
-namespace AspectCore.Extensions.Windsor.Test
+namespace AspectCoreTest.Windsor
 {
     [AttributeUsage(AttributeTargets.Method)]
     public class AsyncIncreamentAttribute : AbstractInterceptorAttribute

--- a/extras/test/AspectCore.Extensions.Windsor.Test/AwaitBeforeInvokeNextTests.cs
+++ b/extras/test/AspectCore.Extensions.Windsor.Test/AwaitBeforeInvokeNextTests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AspectCore.DynamicProxy;
+using AspectCore.Extensions.Windsor;
+using Castle.Core;
+using Castle.MicroKernel.Registration;
+using Castle.Windsor;
+using Xunit;
+
+namespace AspectCoreTest.Windsor
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public class AwaitBeforeInvokeAttribute : AbstractInterceptorAttribute
+    {
+        public override async Task Invoke(AspectContext context, AspectDelegate next)
+        {
+            await Task.Delay(100);
+            if (context.Proxy is AwaitBeforeInvokeTester tester
+                && tester.Cts.IsCancellationRequested)
+            {
+                context.ReturnValue = Task.FromResult(-1);
+                return;
+            }
+            await context.Invoke(next);
+        }
+    }
+
+    public class AwaitBeforeInvokeTester
+    {
+        [DoNotWire]
+        public CancellationTokenSource Cts { get; set; }
+
+        [AwaitBeforeInvoke]
+        public virtual async Task<int> ExecuteAsync()
+        {
+            await Task.Delay(100);
+            return 1;
+        }
+    }
+
+    public class AwaitBeforeInvokeNextTests
+    {
+        private IWindsorContainer CreateWindsorContainer()
+        {
+            return new WindsorContainer()
+                .AddAspectCoreFacility()
+                .Register(Component.For<AwaitBeforeInvokeTester>().LifestyleTransient());
+        }
+
+        [Fact]
+        public async Task Test()
+        {
+            var container = CreateWindsorContainer();
+            var service = container.Resolve<AwaitBeforeInvokeTester>();
+            service.Cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var result = await service.ExecuteAsync();
+            Assert.Equal(1, result);
+            Assert.False(service.Cts.IsCancellationRequested);
+        }
+    }
+}

--- a/extras/test/AspectCore.Extensions.Windsor.Test/Fakes/CacheInterceptorAttribute.cs
+++ b/extras/test/AspectCore.Extensions.Windsor.Test/Fakes/CacheInterceptorAttribute.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using AspectCore.DynamicProxy;
 using AspectCore.DynamicProxy.Parameters;
 
-namespace AspectCore.Extensions.Windsor.Test.Fakes
+namespace AspectCoreTest.Windsor.Fakes
 {
     public class CacheInterceptorAttribute : AbstractInterceptorAttribute
     {

--- a/extras/test/AspectCore.Extensions.Windsor.Test/Fakes/CacheService.cs
+++ b/extras/test/AspectCore.Extensions.Windsor.Test/Fakes/CacheService.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 
-namespace AspectCore.Extensions.Windsor.Test.Fakes
+namespace AspectCoreTest.Windsor.Fakes
 {
     public class CacheService : ICacheService
     {

--- a/extras/test/AspectCore.Extensions.Windsor.Test/Fakes/Controller.cs
+++ b/extras/test/AspectCore.Extensions.Windsor.Test/Fakes/Controller.cs
@@ -1,4 +1,4 @@
-﻿namespace AspectCore.Extensions.Windsor.Test.Fakes
+﻿namespace AspectCoreTest.Windsor.Fakes
 {
     public class Controller : IController
     {

--- a/extras/test/AspectCore.Extensions.Windsor.Test/Fakes/ICacheService.cs
+++ b/extras/test/AspectCore.Extensions.Windsor.Test/Fakes/ICacheService.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 
-namespace AspectCore.Extensions.Windsor.Test.Fakes
+namespace AspectCoreTest.Windsor.Fakes
 {
     public interface ICacheService
     {

--- a/extras/test/AspectCore.Extensions.Windsor.Test/Fakes/IController.cs
+++ b/extras/test/AspectCore.Extensions.Windsor.Test/Fakes/IController.cs
@@ -1,4 +1,4 @@
-﻿namespace AspectCore.Extensions.Windsor.Test.Fakes
+﻿namespace AspectCoreTest.Windsor.Fakes
 {
     [CacheInterceptor]
     public interface IController

--- a/extras/test/AspectCore.Extensions.Windsor.Test/Fakes/Model.cs
+++ b/extras/test/AspectCore.Extensions.Windsor.Test/Fakes/Model.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 
-namespace AspectCore.Extensions.Windsor.Test.Fakes
+namespace AspectCoreTest.Windsor.Fakes
 {
     public class Model
     {

--- a/extras/test/AspectCore.Extensions.Windsor.Test/RegistrationExtensionsTests.cs
+++ b/extras/test/AspectCore.Extensions.Windsor.Test/RegistrationExtensionsTests.cs
@@ -1,12 +1,11 @@
-﻿using System.Reflection;
-using System.Threading.Tasks;
-using AspectCore.DynamicProxy;
-using AspectCore.Extensions.Windsor.Test.Fakes;
+﻿using System.Threading.Tasks;
+using AspectCore.Extensions.Windsor;
+using AspectCoreTest.Windsor.Fakes;
 using Castle.MicroKernel.Registration;
 using Castle.Windsor;
 using Xunit;
 
-namespace AspectCore.Extensions.Windsor.Test
+namespace AspectCoreTest.Windsor
 {
     public class RegistrationExtensionsTests
     {

--- a/extras/test/AspectCore.Extensions.Windsor.Test/ScopedServiceTests.cs
+++ b/extras/test/AspectCore.Extensions.Windsor.Test/ScopedServiceTests.cs
@@ -1,13 +1,13 @@
 using System;
 using System.Threading.Tasks;
+using AspectCore.Configuration;
 using AspectCore.DynamicProxy;
 using AspectCore.Extensions.Windsor;
 using Castle.MicroKernel.Lifestyle;
 using Castle.MicroKernel.Registration;
 using Xunit;
-using AspectCore.Configuration;
 
-namespace AspectCore.Extensions.Windsor.Test
+namespace AspectCoreTest.Windsor
 {
     public class ScopedServiceTests
     {


### PR DESCRIPTION
1.解决#105
2.之前几天ci里面关于windsor的测试一直有死锁问题，尝试了很多种方法都没解决，从昨晚开始不知道为啥就没有死锁问题了（嗯，和我做的所有尝试都无关，估计是ci更新了运行环境吧）
由于不知道是不是仍然还存在死锁的可能性，我参考了
https://stackoverflow.com/questions/28305968/use-task-run-in-synchronous-method-to-avoid-deadlock-waiting-on-async-method
的高票回答，在AspectCore.DynamicProxy.AspectActivator这个类中采用了回答中的方法来避免潜在的死锁