### PR TITLE
fix intercept method with out decimal error

### DIFF
--- a/src/AspectCore.Core/Utils/ProxyGeneratorUtils.cs
+++ b/src/AspectCore.Core/Utils/ProxyGeneratorUtils.cs
@@ -558,12 +558,14 @@ namespace AspectCore.Utils
                         {
                             if (parameters[i].IsByRef)
                             {
+                                Type byrefToType = parameters[i].GetElementType();
+
                                 ilGen.EmitLoadArg(i + 1);
                                 ilGen.Emit(OpCodes.Ldloc, argsLocal);
                                 ilGen.EmitInt(i);
                                 ilGen.Emit(OpCodes.Ldelem_Ref);
                                 ilGen.EmitConvertFromObject(parameters[i].GetElementType());
-                                ilGen.EmitStRef(parameters[i]);
+                                ilGen.EmitStRef(byrefToType);
                             }
                         }
                         if (!method.IsVoid())
@@ -611,12 +613,14 @@ namespace AspectCore.Utils
                         {
                             if (parameterTypes[i].IsByRef)
                             {
+                                Type byrefToType = parameterTypes[i].GetElementType();
+
                                 ilGen.EmitLoadArg(i + 1);
                                 ilGen.Emit(OpCodes.Ldloc, parameters);
                                 ilGen.EmitInt(i);
                                 ilGen.Emit(OpCodes.Ldelem_Ref);
-                                ilGen.EmitConvertFromObject(parameterTypes[i].GetElementType());
-                                ilGen.EmitStRef(parameterTypes[i]);
+                                ilGen.EmitConvertFromObject(byrefToType);
+                                ilGen.EmitStRef(byrefToType);
                             }
                         }
                     }
@@ -917,7 +921,7 @@ namespace AspectCore.Utils
                     // If this bug is present, it is caused by a `null` default value:
                     defaultValue = null;
                 }
-                catch (FormatException) when (from.ParameterType.GetTypeInfo().IsEnum)
+                catch (FormatException) when (from.ParameterType.IsEnum)
                 {
                     // This catch clause guards against a CLR bug that makes it impossible to query
                     // the default value of a (closed generic) enum parameter. For the CoreCLR, see
@@ -962,7 +966,7 @@ namespace AspectCore.Utils
                             // would "produce" a default value of `Missing.Value` in this situation).
                             return;
                         }
-                        else if (parameterType.GetTypeInfo().IsValueType)
+                        else if (parameterType.IsValueType)
                         {
                             // This guards against a CLR bug that prohibits replicating `null` default
                             // values for non-nullable value types (which, despite the apparent type
@@ -978,7 +982,7 @@ namespace AspectCore.Utils
                     else if (isNullableType)
                     {
                         parameterNonNullableType = from.ParameterType.GetGenericArguments()[0];
-                        if (parameterNonNullableType.GetTypeInfo().IsEnum || parameterNonNullableType.IsInstanceOfType(defaultValue))
+                        if (parameterNonNullableType.IsEnum || parameterNonNullableType.IsInstanceOfType(defaultValue))
                         {
                             // This guards against two bugs:
                             //

--- a/src/AspectCore.Extensions.Reflection/Emit/ILGeneratorExtensions.cs
+++ b/src/AspectCore.Extensions.Reflection/Emit/ILGeneratorExtensions.cs
@@ -14,7 +14,25 @@ namespace AspectCore.Extensions.Reflection.Emit
                 throw new ArgumentNullException(nameof(ilGenerator));
             }
 
-            ilGenerator.Emit(OpCodes.Ldarg, index);
+            switch (index)
+            {
+                case 0:
+                    ilGenerator.Emit(OpCodes.Ldarg_0);
+                    break;
+                case 1:
+                    ilGenerator.Emit(OpCodes.Ldarg_1);
+                    break;
+                case 2:
+                    ilGenerator.Emit(OpCodes.Ldarg_2);
+                    break;
+                case 3:
+                    ilGenerator.Emit(OpCodes.Ldarg_3);
+                    break;
+                default:
+                    if (index <= byte.MaxValue) ilGenerator.Emit(OpCodes.Ldarg_S, (byte)index);
+                    else ilGenerator.Emit(OpCodes.Ldarg, index);
+                    break;
+            }
         }
 
         public static void EmitLoadArgA(this ILGenerator ilGenerator, int index)

--- a/src/AspectCore.Extensions.Reflection/Emit/ILGeneratorExtensions.cs
+++ b/src/AspectCore.Extensions.Reflection/Emit/ILGeneratorExtensions.cs
@@ -14,25 +14,7 @@ namespace AspectCore.Extensions.Reflection.Emit
                 throw new ArgumentNullException(nameof(ilGenerator));
             }
 
-            switch (index)
-            {
-                case 0:
-                    ilGenerator.Emit(OpCodes.Ldarg_0);
-                    break;
-                case 1:
-                    ilGenerator.Emit(OpCodes.Ldarg_1);
-                    break;
-                case 2:
-                    ilGenerator.Emit(OpCodes.Ldarg_2);
-                    break;
-                case 3:
-                    ilGenerator.Emit(OpCodes.Ldarg_3);
-                    break;
-                default:
-                    if (index <= byte.MaxValue) ilGenerator.Emit(OpCodes.Ldarg_S, (byte)index);
-                    else ilGenerator.Emit(OpCodes.Ldarg, index);
-                    break;
-            }
+            ilGenerator.Emit(OpCodes.Ldarg, index);
         }
 
         public static void EmitLoadArgA(this ILGenerator ilGenerator, int index)
@@ -210,25 +192,17 @@ namespace AspectCore.Extensions.Reflection.Emit
             {
                 throw new ArgumentNullException(nameof(ilGenerator));
             }
-            if (!typeFrom.IsValueType && typeTo.IsValueType)
+            if (typeFrom.IsValueType)
             {
-                ilGenerator.Emit(OpCodes.Unbox_Any, typeTo.AsType());
-            }
-            else if (typeFrom.IsValueType && !typeTo.IsValueType)
-            {
-                ilGenerator.Emit(OpCodes.Box, typeFrom.AsType());
-                if (typeTo.AsType() != typeof(object))
+                ilGenerator.Emit(OpCodes.Box, typeFrom);
+                if (typeTo != typeof(object))
                 {
-                    ilGenerator.Emit(OpCodes.Castclass, typeTo.AsType());
+                    ilGenerator.Emit(OpCodes.Castclass, typeTo);
                 }
-            }
-            else if (!typeFrom.IsValueType && !typeTo.IsValueType)
-            {
-                ilGenerator.Emit(OpCodes.Castclass, typeTo.AsType());
             }
             else
             {
-                throw new InvalidCastException($"Caanot cast {typeFrom} to {typeTo}.");
+                ilGenerator.Emit(typeTo.IsValueType ? OpCodes.Unbox_Any : OpCodes.Castclass, typeTo);
             }
         }
 
@@ -693,49 +667,48 @@ namespace AspectCore.Extensions.Reflection.Emit
             {
                 throw new ArgumentNullException(nameof(type));
             }
-            if (type == typeof(short))
+            switch (Type.GetTypeCode(type))
             {
-                ilGenerator.Emit(OpCodes.Ldind_I1);
-            }
-            else if (type == typeof(Int16))
-            {
-                ilGenerator.Emit(OpCodes.Ldind_I2);
-            }
-            else if (type == typeof(Int32))
-            {
-                ilGenerator.Emit(OpCodes.Ldind_I4);
-            }
-            else if (type == typeof(Int64))
-            {
-                ilGenerator.Emit(OpCodes.Ldind_I8);
-            }
-            else if (type == typeof(float))
-            {
-                ilGenerator.Emit(OpCodes.Ldind_R4);
-            }
-            else if (type == typeof(double))
-            {
-                ilGenerator.Emit(OpCodes.Ldind_R8);
-            }
-            else if (type == typeof(ushort))
-            {
-                ilGenerator.Emit(OpCodes.Ldind_U1);
-            }
-            else if (type == typeof(UInt16))
-            {
-                ilGenerator.Emit(OpCodes.Ldind_U2);
-            }
-            else if (type == typeof(UInt32))
-            {
-                ilGenerator.Emit(OpCodes.Ldind_U4);
-            }
-            else if (type.GetTypeInfo().IsValueType)
-            {
-                ilGenerator.Emit(OpCodes.Ldobj);
-            }
-            else
-            {
-                ilGenerator.Emit(OpCodes.Ldind_Ref);
+                case TypeCode.SByte:
+                    ilGenerator.Emit(OpCodes.Ldind_I1);
+                    break;
+                case TypeCode.Boolean:
+                case TypeCode.Byte:
+                    ilGenerator.Emit(OpCodes.Ldind_U1);
+                    break;
+                case TypeCode.Int16:
+                    ilGenerator.Emit(OpCodes.Ldind_I2);
+                    break;
+                case TypeCode.Char:
+                case TypeCode.UInt16:
+                    ilGenerator.Emit(OpCodes.Ldind_U2);
+                    break;
+                case TypeCode.Int32:
+                    ilGenerator.Emit(OpCodes.Ldind_I4);
+                    break;
+                case TypeCode.UInt32:
+                    ilGenerator.Emit(OpCodes.Ldind_U4);
+                    break;
+                case TypeCode.Int64:
+                case TypeCode.UInt64:
+                    ilGenerator.Emit(OpCodes.Ldind_I8);
+                    break;
+                case TypeCode.Single:
+                    ilGenerator.Emit(OpCodes.Ldind_R4);
+                    break;
+                case TypeCode.Double:
+                    ilGenerator.Emit(OpCodes.Ldind_R8);
+                    break;
+                default:
+                    if (type.IsValueType)
+                    {
+                        ilGenerator.Emit(OpCodes.Ldobj, type);
+                    }
+                    else
+                    {
+                        ilGenerator.Emit(OpCodes.Ldind_Ref);
+                    }
+                    break;
             }
         }
 
@@ -749,37 +722,42 @@ namespace AspectCore.Extensions.Reflection.Emit
             {
                 throw new ArgumentNullException(nameof(type));
             }
-            if (type == typeof(short))
+            switch (Type.GetTypeCode(type))
             {
-                ilGenerator.Emit(OpCodes.Stind_I1);
-            }
-            else if (type == typeof(Int16))
-            {
-                ilGenerator.Emit(OpCodes.Stind_I2);
-            }
-            else if (type == typeof(Int32))
-            {
-                ilGenerator.Emit(OpCodes.Stind_I4);
-            }
-            else if (type == typeof(Int64))
-            {
-                ilGenerator.Emit(OpCodes.Stind_I8);
-            }
-            else if (type == typeof(float))
-            {
-                ilGenerator.Emit(OpCodes.Stind_R4);
-            }
-            else if (type == typeof(double))
-            {
-                ilGenerator.Emit(OpCodes.Stind_R8);
-            }
-            else if (type.GetTypeInfo().IsValueType)
-            {
-                ilGenerator.Emit(OpCodes.Stobj);
-            }
-            else
-            {
-                ilGenerator.Emit(OpCodes.Stind_Ref);
+                case TypeCode.Boolean:
+                case TypeCode.Byte:
+                case TypeCode.SByte:
+                    ilGenerator.Emit(OpCodes.Stind_I1);
+                    break;
+                case TypeCode.Char:
+                case TypeCode.Int16:
+                case TypeCode.UInt16:
+                    ilGenerator.Emit(OpCodes.Stind_I2);
+                    break;
+                case TypeCode.Int32:
+                case TypeCode.UInt32:
+                    ilGenerator.Emit(OpCodes.Stind_I4);
+                    break;
+                case TypeCode.Int64:
+                case TypeCode.UInt64:
+                    ilGenerator.Emit(OpCodes.Stind_I8);
+                    break;
+                case TypeCode.Single:
+                    ilGenerator.Emit(OpCodes.Stind_R4);
+                    break;
+                case TypeCode.Double:
+                    ilGenerator.Emit(OpCodes.Stind_R8);
+                    break;
+                default:
+                    if (type.IsValueType)
+                    {
+                        ilGenerator.Emit(OpCodes.Stobj, type);
+                    }
+                    else
+                    {
+                        ilGenerator.Emit(OpCodes.Stind_Ref);
+                    }
+                    break;
             }
         }
 

--- a/tests/AspectCore.Extensions.Autofac.Test/AspectCore.Extensions.Autofac.Test.csproj
+++ b/tests/AspectCore.Extensions.Autofac.Test/AspectCore.Extensions.Autofac.Test.csproj
@@ -27,8 +27,6 @@
     </PackageReference>
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
-    <PackageReference Include="System.Linq" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/AspectCore.Extensions.Autofac.Test/Fakes/FakeServiceWithOut.cs
+++ b/tests/AspectCore.Extensions.Autofac.Test/Fakes/FakeServiceWithOut.cs
@@ -1,0 +1,37 @@
+﻿using System.Globalization;
+using System.Threading.Tasks;
+using AspectCore.DynamicProxy;
+
+namespace AspectCore.Extensions.Test.Fakes
+{
+    public class FakeServiceWithOutInterceptor : AbstractInterceptorAttribute
+    {
+        public override async Task Invoke(AspectContext context, AspectDelegate next)
+        {
+            await next(context);
+        }
+    }
+
+    [FakeServiceWithOutInterceptor]
+    public interface IFakeServiceWithOut
+    {
+        bool OutDecimal(out decimal num);
+
+        bool OutInt(out int num);
+    }
+
+    public class FakeServiceWithOut : IFakeServiceWithOut
+    {
+        public bool OutDecimal(out decimal num)
+        {
+            num = 1.0M;
+            return true;
+        }
+
+        public bool OutInt(out int num)
+        {
+            num = 1;
+            return true;
+        }
+    }
+}

--- a/tests/AspectCore.Extensions.Autofac.Test/RegistrationExtensionsTests.cs
+++ b/tests/AspectCore.Extensions.Autofac.Test/RegistrationExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using AspectCore.Configuration;
+using AspectCore.DependencyInjection;
 using AspectCore.DynamicProxy;
 using AspectCore.Extensions.Autofac;
 using AspectCore.Extensions.Test.Fakes;
@@ -66,6 +67,32 @@ namespace AspectCoreTest.Autofac
 
             var proxyController = container.Resolve<IController>();
             Assert.Equal(proxyService.Get(100), proxyController.Execute());
+        }
+
+        [Fact]
+        public void Intercept_OutWithDecimalParamter_Test()
+        {
+            var builder = CreateBuilder();
+            builder.RegisterType<FakeServiceWithOut>().As<IFakeServiceWithOut>();
+            var container = builder.Build();
+
+            var proxyServiceWithOut = container.Resolve<IFakeServiceWithOut>();
+            decimal num;
+            Assert.True(proxyServiceWithOut.OutDecimal(out num));
+            Assert.Equal(1.0M, num);
+        }
+
+        [Fact]
+        public void Intercept_OutWithIntParamter_Test()
+        {
+            var builder = CreateBuilder();
+            builder.RegisterType<FakeServiceWithOut>().As<IFakeServiceWithOut>();
+            var container = builder.Build();
+
+            var proxyServiceWithOut = container.Resolve<IFakeServiceWithOut>();
+            int num;
+            Assert.True(proxyServiceWithOut.OutInt(out num));
+            Assert.Equal(1, num);
         }
     }
 }

--- a/tests/AspectCore.Tests/Classes.cs
+++ b/tests/AspectCore.Tests/Classes.cs
@@ -243,4 +243,35 @@ namespace AspectCore.Tests
             return "lemon";
         }
     }
+
+    public class FakeServiceWithOutInterceptor : AbstractInterceptorAttribute
+    {
+        public override async Task Invoke(AspectContext context, AspectDelegate next)
+        {
+            await next(context);
+        }
+    }
+
+    [FakeServiceWithOutInterceptor]
+    public interface IFakeServiceWithOut
+    {
+        bool OutDecimal(out decimal num);
+
+        bool OutInt(out int num);
+    }
+
+    public class FakeServiceWithOut : IFakeServiceWithOut
+    {
+        public bool OutDecimal(out decimal num)
+        {
+            num = 1.0M;
+            return true;
+        }
+
+        public bool OutInt(out int num)
+        {
+            num = 1;
+            return true;
+        }
+    }
 }

--- a/tests/AspectCore.Tests/DynamicProxy/AsyncAspectTests.cs
+++ b/tests/AspectCore.Tests/DynamicProxy/AsyncAspectTests.cs
@@ -4,6 +4,7 @@ using AspectCore.DynamicProxy;
 using System.Text;
 using Xunit;
 using System.Threading.Tasks;
+using AspectCore.DependencyInjection;
 
 namespace AspectCore.Tests.DynamicProxy
 {

--- a/tests/AspectCore.Tests/Injector/GenericTest.cs
+++ b/tests/AspectCore.Tests/Injector/GenericTest.cs
@@ -32,11 +32,30 @@ namespace AspectCore.Tests.Injector
             Assert.IsType<SimpleGeneric<IService>>(service);
         }
 
+        [Fact]
+        public void Intercept_OutWithDecimalParamter_Test()
+        {
+            var service = ServiceResolver.Resolve<IFakeServiceWithOut>();
+            decimal num;
+            Assert.True(service.OutDecimal(out num));
+            Assert.Equal(1.0M, num);
+        }
+
+        [Fact]
+        public void Intercept_OutWithIntParamter_Test()
+        {
+            var service = ServiceResolver.Resolve<IFakeServiceWithOut>();
+            int num;
+            Assert.True(service.OutInt(out num));
+            Assert.Equal(1, num);
+        }
+
         protected override void ConfigureService(IServiceContext services)
         {
             services.Transients.AddType(typeof(ISimpleGeneric<>), typeof(SimpleGeneric<>));
             services.Transients.AddDelegate(typeof(IDelegateSimpleGeneric<>), r => new SimpleGeneric<IService>());
             services.Singletons.AddInstance(typeof(IInstanceSimpleGeneric<>), new SimpleGeneric<IService>());
+            services.Transients.AddType<IFakeServiceWithOut, FakeServiceWithOut>();
         }
     }
 }


### PR DESCRIPTION
1.修复当方法中包含out decimal时，加上拦截器，在.net5.0下会报内存错误，在.netcoreapp3.1下会out参数未正确返回（即返回值未赋值）的问题。（ProxyGeneratorUtils.cs中修复）
2.调试过程中更新了部分ILGeneratorExtensions.cs中实现。参考的官方dotnet/runtime库中System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs

PS.appveyor编译不通过的问题在另外一个PR修复了。#256