### PR TITLE
fix #289

### DIFF
--- a/src/AspectCore.Core/Configuration/Predicates.cs
+++ b/src/AspectCore.Core/Configuration/Predicates.cs
@@ -23,12 +23,17 @@ namespace AspectCore.Configuration
 
             return method =>
             {
-                if (method.DeclaringType.Name.Matches(service))
+                var declaringType = method.DeclaringType;
+                var declaringTypeName = declaringType.Name;
+                if (declaringType.IsGenericType)
+                {
+                    declaringTypeName = declaringTypeName.Split('`')[0];
+                }
+                if (declaringTypeName.Matches(service))
                 {
                     return true;
                 }
 
-                var declaringType = method.DeclaringType;
                 var fullName = declaringType.FullName ?? $"{declaringType.Name}.{declaringType.Name}";
                 return fullName.Matches(service);
             };


### PR DESCRIPTION
泛型取出的TypeName结尾会带有`1等标识，所以表达式进行匹配会失败
增加特殊处理