### PR TITLE
Update Predicates.cs

### DIFF
--- a/src/AspectCore.Core/Configuration/Predicates.cs
+++ b/src/AspectCore.Core/Configuration/Predicates.cs
@@ -10,8 +10,10 @@ namespace AspectCore.Configuration
             {
                 throw new ArgumentNullException(nameof(nameSpace));
             }
-
-            return method => method.DeclaringType.Namespace.Matches(nameSpace);
+            
+            return method => nameSpace == method.DeclaringType.Namespace ||
+                             (method.DeclaringType.Namespace != null && 
+                              method.DeclaringType.Namespace.Matches(nameSpace));
         }
 
         public static AspectPredicate ForService(string service)


### PR DESCRIPTION
Without the given treatment, entities without a namespace (global), generate an error at startup when creating the ServiceProvider