### PR TITLE
Add .NET8 target

### DIFF
--- a/benchmark/AspectCore.Core.Benchmark/AspectCore.Core.Benchmark.csproj
+++ b/benchmark/AspectCore.Core.Benchmark/AspectCore.Core.Benchmark.csproj
@@ -19,7 +19,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/benchmark/AspectCore.Core.Benchmark/AspectCore.Core.Benchmark.csproj
+++ b/benchmark/AspectCore.Core.Benchmark/AspectCore.Core.Benchmark.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\sign.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/benchmark/AspectCore.Core.Benchmark/AspectCore.Core.Benchmark.csproj
+++ b/benchmark/AspectCore.Core.Benchmark/AspectCore.Core.Benchmark.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\sign.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/benchmark/AspectCore.Extensions.Reflection.Benchmark/AspectCore.Extensions.Reflection.Benchmark.csproj
+++ b/benchmark/AspectCore.Extensions.Reflection.Benchmark/AspectCore.Extensions.Reflection.Benchmark.csproj
@@ -13,7 +13,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.13.11" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/benchmark/AspectCore.Extensions.Reflection.Benchmark/AspectCore.Extensions.Reflection.Benchmark.csproj
+++ b/benchmark/AspectCore.Extensions.Reflection.Benchmark/AspectCore.Extensions.Reflection.Benchmark.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/benchmark/AspectCore.Extensions.Reflection.Benchmark/AspectCore.Extensions.Reflection.Benchmark.csproj
+++ b/benchmark/AspectCore.Extensions.Reflection.Benchmark/AspectCore.Extensions.Reflection.Benchmark.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/sample/AspectCore.Extensions.Autofac.Sample/AspectCore.Extensions.Autofac.Sample.csproj
+++ b/sample/AspectCore.Extensions.Autofac.Sample/AspectCore.Extensions.Autofac.Sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/sample/AspectCore.Extensions.Autofac.Sample/AspectCore.Extensions.Autofac.Sample.csproj
+++ b/sample/AspectCore.Extensions.Autofac.Sample/AspectCore.Extensions.Autofac.Sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/sample/AspectCore.Extensions.DependencyInjection.ConsoleSample/AspectCore.Extensions.DependencyInjection.ConsoleSample.csproj
+++ b/sample/AspectCore.Extensions.DependencyInjection.ConsoleSample/AspectCore.Extensions.DependencyInjection.ConsoleSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/sample/AspectCore.Extensions.DependencyInjection.ConsoleSample/AspectCore.Extensions.DependencyInjection.ConsoleSample.csproj
+++ b/sample/AspectCore.Extensions.DependencyInjection.ConsoleSample/AspectCore.Extensions.DependencyInjection.ConsoleSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Abstractions/AspectCore.Abstractions.csproj
+++ b/src/AspectCore.Abstractions/AspectCore.Abstractions.csproj
@@ -9,7 +9,7 @@
     <PackageId>AspectCore.Abstractions</PackageId>
     <PackageTags>DynamicProxy;Aop;Aspect;AspectCore;Interceptor</PackageTags>
     <PackageReleaseNotes>The abstract design of the AspectCore framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -19,13 +19,8 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
-  
   <ItemGroup>
     <Folder Include="Properties\" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
   
 </Project>

--- a/src/AspectCore.Abstractions/AspectCore.Abstractions.csproj
+++ b/src/AspectCore.Abstractions/AspectCore.Abstractions.csproj
@@ -9,7 +9,7 @@
     <PackageId>AspectCore.Abstractions</PackageId>
     <PackageTags>DynamicProxy;Aop;Aspect;AspectCore;Interceptor</PackageTags>
     <PackageReleaseNotes>The abstract design of the AspectCore framework.</PackageReleaseNotes>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Abstractions/AspectCore.Abstractions.csproj
+++ b/src/AspectCore.Abstractions/AspectCore.Abstractions.csproj
@@ -15,6 +15,18 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+	</ItemGroup>
+	
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>

--- a/src/AspectCore.Abstractions/DependencyInjection/IServiceResolver.cs
+++ b/src/AspectCore.Abstractions/DependencyInjection/IServiceResolver.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using AspectCore.DynamicProxy;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace AspectCore.DependencyInjection
 {
     [NonAspect]
     public interface IServiceResolver : IServiceProvider, IDisposable
+#if NET8_0_OR_GREATER
+        , IKeyedServiceProvider
+#endif
     {
         object Resolve(Type serviceType);
     }

--- a/src/AspectCore.Core/AspectCore.Core.csproj
+++ b/src/AspectCore.Core/AspectCore.Core.csproj
@@ -8,7 +8,7 @@
     <PackageId>AspectCore.Core</PackageId>
     <PackageTags>DynamicProxy;Aop;Aspect;AspectCore;Interceptor</PackageTags>
     <PackageReleaseNotes>The implementation of the AspectCore framework.</PackageReleaseNotes>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Core/AspectCore.Core.csproj
+++ b/src/AspectCore.Core/AspectCore.Core.csproj
@@ -8,7 +8,7 @@
     <PackageId>AspectCore.Core</PackageId>
     <PackageTags>DynamicProxy;Aop;Aspect;AspectCore;Interceptor</PackageTags>
     <PackageReleaseNotes>The implementation of the AspectCore framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -21,12 +21,6 @@
   <ItemGroup>
     <ProjectReference Include="..\AspectCore.Abstractions\AspectCore.Abstractions.csproj" />
     <ProjectReference Include="..\AspectCore.Extensions.Reflection\AspectCore.Extensions.Reflection.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
-    <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.7.0" />
   </ItemGroup>
 
 </Project>

--- a/src/AspectCore.Core/DependencyInjection/ServiceResolver.cs
+++ b/src/AspectCore.Core/DependencyInjection/ServiceResolver.cs
@@ -72,6 +72,18 @@ namespace AspectCore.DependencyInjection
             }
         }
 
+#if NET8_0_OR_GREATER
+        public object GetKeyedService(Type serviceType, object serviceKey)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object GetRequiredKeyedService(Type serviceType, object serviceKey)
+        {
+            throw new NotImplementedException();
+        }
+#endif
+
         #region IDisposable Support
         private bool disposedValue = false;
 

--- a/src/AspectCore.Extensions.AspNetCore/AspectCore.Extensions.AspNetCore.csproj
+++ b/src/AspectCore.Extensions.AspNetCore/AspectCore.Extensions.AspNetCore.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Extensions.AspNetCore/AspectCore.Extensions.AspNetCore.csproj
+++ b/src/AspectCore.Extensions.AspNetCore/AspectCore.Extensions.AspNetCore.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Extensions.AspectScope/AspectCore.Extensions.AspectScope.csproj
+++ b/src/AspectCore.Extensions.AspectScope/AspectCore.Extensions.AspectScope.csproj
@@ -10,7 +10,7 @@
     <Title>AspectCore.Extensions.AspectScope</Title>
     <PackageTags>DynamicProxy;Aop;Aspect;AspectCore;Intercepter</PackageTags>
     <PackageReleaseNotes>ScopedContext extension system for AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Extensions.AspectScope/AspectCore.Extensions.AspectScope.csproj
+++ b/src/AspectCore.Extensions.AspectScope/AspectCore.Extensions.AspectScope.csproj
@@ -10,7 +10,7 @@
     <Title>AspectCore.Extensions.AspectScope</Title>
     <PackageTags>DynamicProxy;Aop;Aspect;AspectCore;Intercepter</PackageTags>
     <PackageReleaseNotes>ScopedContext extension system for AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -19,7 +19,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
-
 
   <ItemGroup>
     <ProjectReference Include="..\AspectCore.Core\AspectCore.Core.csproj" />

--- a/src/AspectCore.Extensions.Autofac/AspectCore.Extensions.Autofac.csproj
+++ b/src/AspectCore.Extensions.Autofac/AspectCore.Extensions.Autofac.csproj
@@ -9,7 +9,7 @@
     <PackageId>AspectCore.Extensions.Autofac</PackageId>
     <PackageTags>DynamicProxy;Aop;Autofac;AspectCore</PackageTags>
     <PackageReleaseNotes>Interceptor and dynamicProxy support for Autofac via AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Extensions.Autofac/AspectCore.Extensions.Autofac.csproj
+++ b/src/AspectCore.Extensions.Autofac/AspectCore.Extensions.Autofac.csproj
@@ -9,7 +9,7 @@
     <PackageId>AspectCore.Extensions.Autofac</PackageId>
     <PackageTags>DynamicProxy;Aop;Autofac;AspectCore</PackageTags>
     <PackageReleaseNotes>Interceptor and dynamicProxy support for Autofac via AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Extensions.Autofac/AutofacServiceResolver.cs
+++ b/src/AspectCore.Extensions.Autofac/AutofacServiceResolver.cs
@@ -30,5 +30,17 @@ namespace AspectCore.Extensions.Autofac
         {
             return _componentContext.ResolveOptional(serviceType);
         }
+
+#if NET8_0_OR_GREATER
+        public object GetKeyedService(Type serviceType, object serviceKey)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object GetRequiredKeyedService(Type serviceType, object serviceKey)
+        {
+            throw new NotImplementedException();
+        }
+#endif
     }
 }

--- a/src/AspectCore.Extensions.Configuration/AspectCore.Extensions.Configuration.csproj
+++ b/src/AspectCore.Extensions.Configuration/AspectCore.Extensions.Configuration.csproj
@@ -8,17 +8,12 @@
 		<PackageId>AspectCore.Extensions.Configuration</PackageId>
 		<PackageTags>Reflection;Aop;DynamicProxy;Configuration</PackageTags>
 		<PackageReleaseNotes>Configuration extension system for ASP.NET Core via AspectCore-Framework.</PackageReleaseNotes>
-		<TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
 
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' ">
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
-	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />

--- a/src/AspectCore.Extensions.Configuration/AspectCore.Extensions.Configuration.csproj
+++ b/src/AspectCore.Extensions.Configuration/AspectCore.Extensions.Configuration.csproj
@@ -8,7 +8,7 @@
 		<PackageId>AspectCore.Extensions.Configuration</PackageId>
 		<PackageTags>Reflection;Aop;DynamicProxy;Configuration</PackageTags>
 		<PackageReleaseNotes>Configuration extension system for ASP.NET Core via AspectCore-Framework.</PackageReleaseNotes>
-		<TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
 
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<IncludeSymbols>true</IncludeSymbols>
@@ -28,6 +28,11 @@
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/AspectCore.Extensions.DataAnnotations/AspectCore.Extensions.DataAnnotations.csproj
+++ b/src/AspectCore.Extensions.DataAnnotations/AspectCore.Extensions.DataAnnotations.csproj
@@ -9,7 +9,7 @@
     <PackageId>AspectCore.Extensions.DataAnnotations</PackageId>
     <PackageTags>DataValidation;DataAnnotations;AspectCore;AOP</PackageTags>
     <PackageReleaseNotes>DataAnnotations extension system for AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Extensions.DataAnnotations/AspectCore.Extensions.DataAnnotations.csproj
+++ b/src/AspectCore.Extensions.DataAnnotations/AspectCore.Extensions.DataAnnotations.csproj
@@ -9,7 +9,7 @@
     <PackageId>AspectCore.Extensions.DataAnnotations</PackageId>
     <PackageTags>DataValidation;DataAnnotations;AspectCore;AOP</PackageTags>
     <PackageReleaseNotes>DataAnnotations extension system for AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Extensions.DataValidation/AspectCore.Extensions.DataValidation.csproj
+++ b/src/AspectCore.Extensions.DataValidation/AspectCore.Extensions.DataValidation.csproj
@@ -9,7 +9,7 @@
     <PackageId>AspectCore.Extensions.DataValidation</PackageId>
     <PackageTags>DataValidation;AspectCore;AOP</PackageTags>
     <PackageReleaseNotes>DataValidation extension system for AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Extensions.DataValidation/AspectCore.Extensions.DataValidation.csproj
+++ b/src/AspectCore.Extensions.DataValidation/AspectCore.Extensions.DataValidation.csproj
@@ -9,7 +9,7 @@
     <PackageId>AspectCore.Extensions.DataValidation</PackageId>
     <PackageTags>DataValidation;AspectCore;AOP</PackageTags>
     <PackageReleaseNotes>DataValidation extension system for AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Extensions.DependencyInjection/AspectCore.Extensions.DependencyInjection.csproj
+++ b/src/AspectCore.Extensions.DependencyInjection/AspectCore.Extensions.DependencyInjection.csproj
@@ -10,7 +10,7 @@
     <PackageTags>DynamicProxy;Aop;DependencyInjection;AspectCore</PackageTags>
     <PackageReleaseNotes>Interceptor and dynamicProxy support for Microsoft.Extensions.DependencyInjection via AspectCore Framework.</PackageReleaseNotes>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -18,10 +18,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' ">
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">

--- a/src/AspectCore.Extensions.DependencyInjection/AspectCore.Extensions.DependencyInjection.csproj
+++ b/src/AspectCore.Extensions.DependencyInjection/AspectCore.Extensions.DependencyInjection.csproj
@@ -10,7 +10,7 @@
     <PackageTags>DynamicProxy;Aop;DependencyInjection;AspectCore</PackageTags>
     <PackageReleaseNotes>Interceptor and dynamicProxy support for Microsoft.Extensions.DependencyInjection via AspectCore Framework.</PackageReleaseNotes>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -32,7 +32,12 @@
 	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+
+
+	<ItemGroup>
     <ProjectReference Include="..\AspectCore.Core\AspectCore.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/AspectCore.Extensions.DependencyInjection/MsdiServiceResolver.cs
+++ b/src/AspectCore.Extensions.DependencyInjection/MsdiServiceResolver.cs
@@ -26,5 +26,17 @@ namespace AspectCore.Extensions.DependencyInjection
         {
             return _serviceProvider.GetService(serviceType);
         }
+
+#if NET8_0_OR_GREATER
+        public object GetKeyedService(Type serviceType, object serviceKey)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object GetRequiredKeyedService(Type serviceType, object serviceKey)
+        {
+            throw new NotImplementedException();
+        }
+#endif
     }
 }

--- a/src/AspectCore.Extensions.DependencyInjection/ServiceCollectionToServiceContextExtensions.cs
+++ b/src/AspectCore.Extensions.DependencyInjection/ServiceCollectionToServiceContextExtensions.cs
@@ -45,6 +45,23 @@ namespace AspectCore.Extensions.DependencyInjection
 
         private static ServiceDefinition Replace(ServiceDescriptor descriptor)
         {
+#if NET8_0_OR_GREATER
+            if (descriptor.IsKeyedService)
+            {
+                if (descriptor.KeyedImplementationType != null)
+                {
+                    return new TypeServiceDefinition(descriptor.ServiceType, descriptor.KeyedImplementationType, GetLifetime(descriptor.Lifetime));
+                }
+                else if (descriptor.KeyedImplementationInstance != null)
+                {
+                    return new InstanceServiceDefinition(descriptor.ServiceType, descriptor.KeyedImplementationInstance);
+                }
+                else
+                {
+                    return new DelegateServiceDefinition(descriptor.ServiceType, resolver => descriptor.KeyedImplementationFactory(resolver, descriptor.ServiceKey), GetLifetime(descriptor.Lifetime));
+                }
+            }
+#endif
             if (descriptor.ImplementationType != null)
             {
                 return new TypeServiceDefinition(descriptor.ServiceType, descriptor.ImplementationType, GetLifetime(descriptor.Lifetime));

--- a/src/AspectCore.Extensions.DependencyInjection/ServiceValidator.cs
+++ b/src/AspectCore.Extensions.DependencyInjection/ServiceValidator.cs
@@ -60,7 +60,48 @@ namespace AspectCore.Extensions.DependencyInjection
             return _aspectValidator.Validate(descriptor.ServiceType, true) || _aspectValidator.Validate(implementationType, false);
         }
 
+#if NET8_0_OR_GREATER
         private Type GetImplementationType(ServiceDescriptor descriptor)
+        {
+            if (descriptor.IsKeyedService)
+            {
+                if (descriptor.KeyedImplementationType != null)
+                {
+                    return descriptor.KeyedImplementationType;
+                }
+                else if (descriptor.KeyedImplementationInstance != null)
+                {
+                    return descriptor.KeyedImplementationInstance.GetType();
+                }
+                else if (descriptor.KeyedImplementationFactory != null)
+                {
+                    var typeArguments = descriptor.KeyedImplementationFactory.GetType().GenericTypeArguments;
+
+                    return typeArguments[1];
+                }
+            }
+            else
+            {
+                if (descriptor.ImplementationType != null)
+                {
+                    return descriptor.ImplementationType;
+                }
+                else if (descriptor.ImplementationInstance != null)
+                {
+                    return descriptor.ImplementationInstance.GetType();
+                }
+                else if (descriptor.ImplementationFactory != null)
+                {
+                    var typeArguments = descriptor.ImplementationFactory.GetType().GenericTypeArguments;
+
+                    return typeArguments[1];
+                }
+            }
+
+            return null;
+        }
+#else
+ private Type GetImplementationType(ServiceDescriptor descriptor)
         {
             if (descriptor.ImplementationType != null)
             {
@@ -78,5 +119,6 @@ namespace AspectCore.Extensions.DependencyInjection
             }
             return null;
         }
+#endif
     }
 }

--- a/src/AspectCore.Extensions.DependencyInjection/ServiceValidator.cs
+++ b/src/AspectCore.Extensions.DependencyInjection/ServiceValidator.cs
@@ -52,17 +52,20 @@ namespace AspectCore.Extensions.DependencyInjection
                 {
                     return false;
                 }
+
                 if (!implementationType.GetTypeInfo().CanInherited())
                 {
                     return false;
                 }
             }
+
             return _aspectValidator.Validate(descriptor.ServiceType, true) || _aspectValidator.Validate(implementationType, false);
         }
 
-#if NET8_0_OR_GREATER
+
         private Type GetImplementationType(ServiceDescriptor descriptor)
         {
+#if NET8_0_OR_GREATER
             if (descriptor.IsKeyedService)
             {
                 if (descriptor.KeyedImplementationType != null)
@@ -79,30 +82,10 @@ namespace AspectCore.Extensions.DependencyInjection
 
                     return typeArguments[1];
                 }
-            }
-            else
-            {
-                if (descriptor.ImplementationType != null)
-                {
-                    return descriptor.ImplementationType;
-                }
-                else if (descriptor.ImplementationInstance != null)
-                {
-                    return descriptor.ImplementationInstance.GetType();
-                }
-                else if (descriptor.ImplementationFactory != null)
-                {
-                    var typeArguments = descriptor.ImplementationFactory.GetType().GenericTypeArguments;
 
-                    return typeArguments[1];
-                }
+                return null;
             }
-
-            return null;
-        }
-#else
- private Type GetImplementationType(ServiceDescriptor descriptor)
-        {
+#endif
             if (descriptor.ImplementationType != null)
             {
                 return descriptor.ImplementationType;
@@ -117,8 +100,8 @@ namespace AspectCore.Extensions.DependencyInjection
 
                 return typeArguments[1];
             }
+
             return null;
         }
-#endif
     }
 }

--- a/src/AspectCore.Extensions.Hosting/AspectCore.Extensions.Hosting.csproj
+++ b/src/AspectCore.Extensions.Hosting/AspectCore.Extensions.Hosting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -21,6 +21,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
 	  <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+	  <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspectCore.Extensions.Hosting/AspectCore.Extensions.Hosting.csproj
+++ b/src/AspectCore.Extensions.Hosting/AspectCore.Extensions.Hosting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -9,10 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' ">
-	  <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">

--- a/src/AspectCore.Extensions.LightInject/AspectCore.Extensions.LightInject.csproj
+++ b/src/AspectCore.Extensions.LightInject/AspectCore.Extensions.LightInject.csproj
@@ -7,7 +7,7 @@
     <PackageTags>DynamicProxy;Aop;LightInject;AspectCore</PackageTags>
     <PackageReleaseNotes>Interceptor and dynamicProxy support for LightInject via AspectCore Framework.</PackageReleaseNotes>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>	
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Extensions.LightInject/AspectCore.Extensions.LightInject.csproj
+++ b/src/AspectCore.Extensions.LightInject/AspectCore.Extensions.LightInject.csproj
@@ -7,7 +7,7 @@
     <PackageTags>DynamicProxy;Aop;LightInject;AspectCore</PackageTags>
     <PackageReleaseNotes>Interceptor and dynamicProxy support for LightInject via AspectCore Framework.</PackageReleaseNotes>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>	
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Extensions.LightInject/AspectCore.Extensions.LightInject.csproj
+++ b/src/AspectCore.Extensions.LightInject/AspectCore.Extensions.LightInject.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LightInject" Version="6.6.0" />
+    <PackageReference Include="LightInject" Version="6.6.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AspectCore.Core\AspectCore.Core.csproj" />

--- a/src/AspectCore.Extensions.LightInject/LightInjectServiceResolver.cs
+++ b/src/AspectCore.Extensions.LightInject/LightInjectServiceResolver.cs
@@ -37,5 +37,17 @@ namespace AspectCore.Extensions.LightInject
         {
             return _serviceFactory.TryGetInstance(serviceType);
         }
+
+#if NET8_0_OR_GREATER
+        public object GetKeyedService(Type serviceType, object serviceKey)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object GetRequiredKeyedService(Type serviceType, object serviceKey)
+        {
+            throw new NotImplementedException();
+        }
+#endif
     }
 }

--- a/src/AspectCore.Extensions.Reflection/AspectCore.Extensions.Reflection.csproj
+++ b/src/AspectCore.Extensions.Reflection/AspectCore.Extensions.Reflection.csproj
@@ -8,7 +8,7 @@
     <PackageId>AspectCore.Extensions.Reflection</PackageId>
     <PackageTags>Reflection;Aop;DynamicProxy</PackageTags>
     <PackageReleaseNotes>Reflection extension system for AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Extensions.Reflection/AspectCore.Extensions.Reflection.csproj
+++ b/src/AspectCore.Extensions.Reflection/AspectCore.Extensions.Reflection.csproj
@@ -8,7 +8,7 @@
     <PackageId>AspectCore.Extensions.Reflection</PackageId>
     <PackageTags>Reflection;Aop;DynamicProxy</PackageTags>
     <PackageReleaseNotes>Reflection extension system for AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -17,14 +17,5 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
-
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-
-  </ItemGroup>
+	
 </Project>

--- a/src/AspectCore.Extensions.Reflection/Extensions/TypeExtensions.cs
+++ b/src/AspectCore.Extensions.Reflection/Extensions/TypeExtensions.cs
@@ -189,13 +189,7 @@ namespace AspectCore.Extensions.Reflection
             {
                 throw new ArgumentNullException(nameof(type));
             }
-#if NET461
-            return false;
-#elif NETSTANDARD2_0
-            return false;
-#else
             return type.IsGenericType && typeof(ITuple).IsAssignableFrom(type.GetTypeInfo().GetGenericTypeDefinition());
-#endif
 
         }
     }

--- a/src/AspectCore.Extensions.Windsor/AspectCore.Extensions.Windsor.csproj
+++ b/src/AspectCore.Extensions.Windsor/AspectCore.Extensions.Windsor.csproj
@@ -9,7 +9,7 @@
     <PackageId>AspectCore.Extensions.Windsor</PackageId>
     <PackageTags>DynamicProxy;Aop;Windsor;AspectCore</PackageTags>
     <PackageReleaseNotes>Interceptor and dynamicProxy support for Castle.Windsor via AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Extensions.Windsor/AspectCore.Extensions.Windsor.csproj
+++ b/src/AspectCore.Extensions.Windsor/AspectCore.Extensions.Windsor.csproj
@@ -9,7 +9,7 @@
     <PackageId>AspectCore.Extensions.Windsor</PackageId>
     <PackageTags>DynamicProxy;Aop;Windsor;AspectCore</PackageTags>
     <PackageReleaseNotes>Interceptor and dynamicProxy support for Castle.Windsor via AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -21,8 +21,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Castle.Windsor" Version="4.1.0" />
-    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+    <PackageReference Include="Castle.Windsor" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspectCore.Extensions.Windsor/WindsorServiceResolver.cs
+++ b/src/AspectCore.Extensions.Windsor/WindsorServiceResolver.cs
@@ -35,5 +35,17 @@ namespace AspectCore.Extensions.Windsor
                 return _kernel.Resolve(serviceType);
             return null;
         }
+
+#if NET8_0_OR_GREATER
+        public object GetKeyedService(Type serviceType, object serviceKey)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object GetRequiredKeyedService(Type serviceType, object serviceKey)
+        {
+            throw new NotImplementedException();
+        }
+#endif
     }
 }

--- a/tests/AspectCore.Extensions.Autofac.Test/AspectCore.Extensions.Autofac.Test.csproj
+++ b/tests/AspectCore.Extensions.Autofac.Test/AspectCore.Extensions.Autofac.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
 		<DebugType>portable</DebugType>
 		<AssemblyName>AspectCore.Extensions.Autofac.Test</AssemblyName>
 		<PackageId>AspectCore.Extensions.Autofac.Test</PackageId>
@@ -32,14 +32,19 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="7.0.0" />
 	</ItemGroup>
 
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+		<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="8.0.0" />
+	</ItemGroup>
+
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit" Version="2.6.2" />
 	</ItemGroup>
 
 </Project>

--- a/tests/AspectCore.Extensions.Autofac.Test/AspectCore.Extensions.Autofac.Test.csproj
+++ b/tests/AspectCore.Extensions.Autofac.Test/AspectCore.Extensions.Autofac.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
 		<DebugType>portable</DebugType>
 		<AssemblyName>AspectCore.Extensions.Autofac.Test</AssemblyName>
 		<PackageId>AspectCore.Extensions.Autofac.Test</PackageId>
@@ -15,11 +15,6 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\AspectCore.Extensions.Autofac\AspectCore.Extensions.Autofac.csproj" />
 		<ProjectReference Include="..\..\src\AspectCore.Extensions.DependencyInjection\AspectCore.Extensions.DependencyInjection.csproj" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'netcoreapp3.1' ">
-		<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="3.1.16" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">

--- a/tests/AspectCore.Extensions.Autofac.Test/AspectCore.Extensions.Autofac.Test.csproj
+++ b/tests/AspectCore.Extensions.Autofac.Test/AspectCore.Extensions.Autofac.Test.csproj
@@ -34,12 +34,12 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-		<PackageReference Include="xunit" Version="2.6.2" />
+		<PackageReference Include="xunit" Version="2.6.4" />
 	</ItemGroup>
 
 </Project>

--- a/tests/AspectCore.Extensions.Configuration.Tests/AspectCore.Extensions.Configuration.Tests.csproj
+++ b/tests/AspectCore.Extensions.Configuration.Tests/AspectCore.Extensions.Configuration.Tests.csproj
@@ -22,8 +22,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="xunit" Version="2.6.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+		<PackageReference Include="xunit" Version="2.6.4" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/tests/AspectCore.Extensions.Configuration.Tests/AspectCore.Extensions.Configuration.Tests.csproj
+++ b/tests/AspectCore.Extensions.Configuration.Tests/AspectCore.Extensions.Configuration.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
@@ -26,10 +26,15 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
 	</ItemGroup>
 
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+	</ItemGroup>
+
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="xunit" Version="2.6.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/tests/AspectCore.Extensions.Configuration.Tests/AspectCore.Extensions.Configuration.Tests.csproj
+++ b/tests/AspectCore.Extensions.Configuration.Tests/AspectCore.Extensions.Configuration.Tests.csproj
@@ -1,20 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
-
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
-	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />

--- a/tests/AspectCore.Extensions.DependencyInjection.Test/AspectCore.Extensions.DependencyInjection.Test.csproj
+++ b/tests/AspectCore.Extensions.DependencyInjection.Test/AspectCore.Extensions.DependencyInjection.Test.csproj
@@ -29,12 +29,12 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-		<PackageReference Include="xunit" Version="2.6.2" />
+		<PackageReference Include="xunit" Version="2.6.4" />
 		<PackageReference Include="System.Reflection" Version="4.3.0" />
 		<PackageReference Include="System.Linq" Version="4.3.0" />
 	</ItemGroup>

--- a/tests/AspectCore.Extensions.DependencyInjection.Test/AspectCore.Extensions.DependencyInjection.Test.csproj
+++ b/tests/AspectCore.Extensions.DependencyInjection.Test/AspectCore.Extensions.DependencyInjection.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
 		<DebugType>portable</DebugType>
 		<AssemblyName>AspectCore.Extensions.DependencyInjection.Test</AssemblyName>
 		<PackageId>AspectCore.Extensions.DependencyInjection.Test</PackageId>
@@ -27,14 +27,18 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="7.0.0" />
 	</ItemGroup>
 
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="8.0.0" />
+	</ItemGroup>
+
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit" Version="2.6.2" />
 		<PackageReference Include="System.Reflection" Version="4.3.0" />
 		<PackageReference Include="System.Linq" Version="4.3.0" />
 	</ItemGroup>

--- a/tests/AspectCore.Extensions.DependencyInjection.Test/AspectCore.Extensions.DependencyInjection.Test.csproj
+++ b/tests/AspectCore.Extensions.DependencyInjection.Test/AspectCore.Extensions.DependencyInjection.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
 		<DebugType>portable</DebugType>
 		<AssemblyName>AspectCore.Extensions.DependencyInjection.Test</AssemblyName>
 		<PackageId>AspectCore.Extensions.DependencyInjection.Test</PackageId>
@@ -13,10 +13,6 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\AspectCore.Extensions.DependencyInjection\AspectCore.Extensions.DependencyInjection.csproj" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'netcoreapp3.1'">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="3.1.16" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">

--- a/tests/AspectCore.Extensions.DependencyInjection.Test/KeyedServiceTests.cs
+++ b/tests/AspectCore.Extensions.DependencyInjection.Test/KeyedServiceTests.cs
@@ -1,0 +1,65 @@
+﻿using System.Threading.Tasks;
+using AspectCore.DynamicProxy;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AspectCore.Extensions.DependencyInjection.Test;
+
+public class KeyedServiceTests
+{
+    public class InterceptKey : AbstractInterceptorAttribute
+    {
+        private int _key;
+
+        public InterceptKey(int key)
+        {
+            _key = key;
+        }
+
+        public override async Task Invoke(AspectContext context, AspectDelegate next)
+        {
+            await context.Invoke(next);
+            context.ReturnValue = _key;
+        }
+    }
+
+    public interface IKeydService
+    {
+        int Get();
+        int GetIntercept();
+    }
+
+    public class KeydService : IKeydService
+    {
+        private int _current = 0;
+        public int Get()
+        {
+            _current++;
+            return _current;
+        }
+
+        [InterceptKey(1000)]
+        public int GetIntercept()
+        {
+            return 2;
+        }
+    }
+#if NET8_0_OR_GREATER
+    [Fact]
+    public void GetKeydService_WithServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddKeyedScoped<IKeydService, KeydService>("key1");
+        services.AddKeyedScoped<IKeydService, KeydService>("key2");
+        var serviceProvider = services.BuildDynamicProxyProvider();
+        var keydService = serviceProvider.GetKeyedService<IKeydService>("key1");
+        Assert.Equal(1, keydService.Get());
+        Assert.Equal(1000, keydService.GetIntercept());
+
+        var keyd2Service = serviceProvider.GetKeyedService<IKeydService>("key2");
+        //不同实例
+        Assert.Equal(1, keyd2Service.Get());
+        Assert.Equal(1000, keyd2Service.GetIntercept());
+    }
+#endif
+}

--- a/tests/AspectCore.Extensions.Hosting.Tests/AspectCore.Extensions.Hosting.Tests.csproj
+++ b/tests/AspectCore.Extensions.Hosting.Tests/AspectCore.Extensions.Hosting.Tests.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+    <PackageReference Include="xunit" Version="2.6.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/AspectCore.Extensions.Hosting.Tests/AspectCore.Extensions.Hosting.Tests.csproj
+++ b/tests/AspectCore.Extensions.Hosting.Tests/AspectCore.Extensions.Hosting.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
 	  <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/AspectCore.Extensions.Hosting.Tests/AspectCore.Extensions.Hosting.Tests.csproj
+++ b/tests/AspectCore.Extensions.Hosting.Tests/AspectCore.Extensions.Hosting.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
 	  <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/AspectCore.Extensions.LightInject.Test/AspectCore.Extensions.LightInject.Test.csproj
+++ b/tests/AspectCore.Extensions.LightInject.Test/AspectCore.Extensions.LightInject.Test.csproj
@@ -11,11 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit" Version="2.6.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
 

--- a/tests/AspectCore.Extensions.LightInject.Test/AspectCore.Extensions.LightInject.Test.csproj
+++ b/tests/AspectCore.Extensions.LightInject.Test/AspectCore.Extensions.LightInject.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/tests/AspectCore.Extensions.LightInject.Test/AspectCore.Extensions.LightInject.Test.csproj
+++ b/tests/AspectCore.Extensions.LightInject.Test/AspectCore.Extensions.LightInject.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <DebugType>portable</DebugType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -11,12 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AspectCore.Extensions.Reflection.Test/AspectCore.Extensions.Reflection.Test.csproj
+++ b/tests/AspectCore.Extensions.Reflection.Test/AspectCore.Extensions.Reflection.Test.csproj
@@ -24,12 +24,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="xunit" Version="2.6.4" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AspectCore.Extensions.Reflection.Test/AspectCore.Extensions.Reflection.Test.csproj
+++ b/tests/AspectCore.Extensions.Reflection.Test/AspectCore.Extensions.Reflection.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>AspectCore.Extensions.Reflection.Test</AssemblyName>
     <PackageId>AspectCore.Extensions.Reflection.Test</PackageId>
@@ -22,13 +22,13 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit" Version="2.6.2" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
   </ItemGroup>
 

--- a/tests/AspectCore.Extensions.Reflection.Test/AspectCore.Extensions.Reflection.Test.csproj
+++ b/tests/AspectCore.Extensions.Reflection.Test/AspectCore.Extensions.Reflection.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>AspectCore.Extensions.Reflection.Test</AssemblyName>
     <PackageId>AspectCore.Extensions.Reflection.Test</PackageId>

--- a/tests/AspectCore.Extensions.Windsor.Test/AspectCore.Extensions.Windsor.Test.csproj
+++ b/tests/AspectCore.Extensions.Windsor.Test/AspectCore.Extensions.Windsor.Test.csproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
 	  <IsPackable>false</IsPackable>
 	  <RootNamespace>AspectCoreTest.Windsor</RootNamespace>
   </PropertyGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'netcoreapp3.1'">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="3.1.16" />
-	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="6.0.0" />

--- a/tests/AspectCore.Extensions.Windsor.Test/AspectCore.Extensions.Windsor.Test.csproj
+++ b/tests/AspectCore.Extensions.Windsor.Test/AspectCore.Extensions.Windsor.Test.csproj
@@ -20,8 +20,8 @@
 
   <ItemGroup>
 	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+    <PackageReference Include="xunit" Version="2.6.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/AspectCore.Extensions.Windsor.Test/AspectCore.Extensions.Windsor.Test.csproj
+++ b/tests/AspectCore.Extensions.Windsor.Test/AspectCore.Extensions.Windsor.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
 	  <IsPackable>false</IsPackable>
 	  <RootNamespace>AspectCoreTest.Windsor</RootNamespace>
   </PropertyGroup>
@@ -18,10 +18,14 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="7.0.0" />
 	</ItemGroup>
 
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="8.0.0" />
+	</ItemGroup>
+
   <ItemGroup>
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/AspectCore.Tests/AspectCore.Tests.csproj
+++ b/tests/AspectCore.Tests/AspectCore.Tests.csproj
@@ -18,8 +18,8 @@
 
   <ItemGroup>
 	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+    <PackageReference Include="xunit" Version="2.6.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/AspectCore.Tests/AspectCore.Tests.csproj
+++ b/tests/AspectCore.Tests/AspectCore.Tests.csproj
@@ -1,12 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'netcoreapp3.1'">
-		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.7" />
-	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
 		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="6.0.11" />

--- a/tests/AspectCore.Tests/AspectCore.Tests.csproj
+++ b/tests/AspectCore.Tests/AspectCore.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -16,10 +16,14 @@
 		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.0" />
 	</ItemGroup>
 
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.0" />
+	</ItemGroup>
+
   <ItemGroup>
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
- [x] 添加.NET8目标
- [x] 调整部分项目目标，移除不再支持的目标版本
- [x] 调整包版本
- [x] 支持.NET8根据名称注入。暂时支持MS默认的ServiceProvider，可使用AOP，包括AspectCore在内的其他第三方DI，需要实现相关IKeyedServiceProvider相关接口，并内部处理ServiceKey。
~~- [ ] 其他事项~~