### PR TITLE
Update Build Target

### DIFF
--- a/benchmark/AspectCore.Core.Benchmark/AspectCore.Core.Benchmark.csproj
+++ b/benchmark/AspectCore.Core.Benchmark/AspectCore.Core.Benchmark.csproj
@@ -14,12 +14,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.11" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/benchmark/AspectCore.Core.Benchmark/AspectCore.Core.Benchmark.csproj
+++ b/benchmark/AspectCore.Core.Benchmark/AspectCore.Core.Benchmark.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\sign.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/benchmark/AspectCore.Extensions.Reflection.Benchmark/AspectCore.Extensions.Reflection.Benchmark.csproj
+++ b/benchmark/AspectCore.Extensions.Reflection.Benchmark/AspectCore.Extensions.Reflection.Benchmark.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/benchmark/AspectCore.Extensions.Reflection.Benchmark/AspectCore.Extensions.Reflection.Benchmark.csproj
+++ b/benchmark/AspectCore.Extensions.Reflection.Benchmark/AspectCore.Extensions.Reflection.Benchmark.csproj
@@ -9,11 +9,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.13.11" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/sample/AspectCore.Extensions.Autofac.Sample/AspectCore.Extensions.Autofac.Sample.csproj
+++ b/sample/AspectCore.Extensions.Autofac.Sample/AspectCore.Extensions.Autofac.Sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/sample/AspectCore.Extensions.Autofac.Sample/AspectCore.Extensions.Autofac.Sample.csproj
+++ b/sample/AspectCore.Extensions.Autofac.Sample/AspectCore.Extensions.Autofac.Sample.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 

--- a/sample/AspectCore.Extensions.DependencyInjection.ConsoleSample/AspectCore.Extensions.DependencyInjection.ConsoleSample.csproj
+++ b/sample/AspectCore.Extensions.DependencyInjection.ConsoleSample/AspectCore.Extensions.DependencyInjection.ConsoleSample.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/AspectCore.Extensions.DependencyInjection.ConsoleSample/AspectCore.Extensions.DependencyInjection.ConsoleSample.csproj
+++ b/sample/AspectCore.Extensions.DependencyInjection.ConsoleSample/AspectCore.Extensions.DependencyInjection.ConsoleSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Abstractions/AspectCore.Abstractions.csproj
+++ b/src/AspectCore.Abstractions/AspectCore.Abstractions.csproj
@@ -9,11 +9,15 @@
 		<PackageId>AspectCore.Abstractions</PackageId>
 		<PackageTags>DynamicProxy;Aop;Aspect;AspectCore;Interceptor</PackageTags>
 		<PackageReleaseNotes>The abstract design of the AspectCore framework.</PackageReleaseNotes>
-		<TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
+	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
@@ -27,8 +31,8 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
-		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/AspectCore.Abstractions/AspectCore.Abstractions.csproj
+++ b/src/AspectCore.Abstractions/AspectCore.Abstractions.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\build\common.props" />
+	<Import Project="..\..\build\common.props" />
 
-  <PropertyGroup>
-    <Description>The abstract design of the AspectCore framework.</Description>
-    <AssemblyTitle>AspectCore.Abstractions</AssemblyTitle>
-    <AssemblyName>AspectCore.Abstractions</AssemblyName>
-    <PackageId>AspectCore.Abstractions</PackageId>
-    <PackageTags>DynamicProxy;Aop;Aspect;AspectCore;Interceptor</PackageTags>
-    <PackageReleaseNotes>The abstract design of the AspectCore framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
+	<PropertyGroup>
+		<Description>The abstract design of the AspectCore framework.</Description>
+		<AssemblyTitle>AspectCore.Abstractions</AssemblyTitle>
+		<AssemblyName>AspectCore.Abstractions</AssemblyName>
+		<PackageId>AspectCore.Abstractions</PackageId>
+		<PackageTags>DynamicProxy;Aop;Aspect;AspectCore;Interceptor</PackageTags>
+		<PackageReleaseNotes>The abstract design of the AspectCore framework.</PackageReleaseNotes>
+		<TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	</PropertyGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
@@ -26,13 +26,17 @@
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
 	</ItemGroup>
-	
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
-  
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Folder Include="Properties\" />
+	</ItemGroup>
+
 </Project>

--- a/src/AspectCore.Abstractions/DependencyInjection/IServiceResolver.cs
+++ b/src/AspectCore.Abstractions/DependencyInjection/IServiceResolver.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using AspectCore.DynamicProxy;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace AspectCore.DependencyInjection
 {
     [NonAspect]
     public interface IServiceResolver : IServiceProvider, IDisposable
 #if NET8_0_OR_GREATER
-        , IKeyedServiceProvider
+        , Microsoft.Extensions.DependencyInjection.IKeyedServiceProvider
 #endif
     {
         object Resolve(Type serviceType);

--- a/src/AspectCore.Core/AspectCore.Core.csproj
+++ b/src/AspectCore.Core/AspectCore.Core.csproj
@@ -8,7 +8,7 @@
     <PackageId>AspectCore.Core</PackageId>
     <PackageTags>DynamicProxy;Aop;Aspect;AspectCore;Interceptor</PackageTags>
     <PackageReleaseNotes>The implementation of the AspectCore framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>.net9.0;net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Core/AspectCore.Core.csproj
+++ b/src/AspectCore.Core/AspectCore.Core.csproj
@@ -8,19 +8,23 @@
     <PackageId>AspectCore.Core</PackageId>
     <PackageTags>DynamicProxy;Aop;Aspect;AspectCore;Interceptor</PackageTags>
     <PackageReleaseNotes>The implementation of the AspectCore framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\AspectCore.Abstractions\AspectCore.Abstractions.csproj" />
     <ProjectReference Include="..\AspectCore.Extensions.Reflection\AspectCore.Extensions.Reflection.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+	  <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>
 
 </Project>

--- a/src/AspectCore.Extensions.AspNetCore/AspectCore.Extensions.AspNetCore.csproj
+++ b/src/AspectCore.Extensions.AspNetCore/AspectCore.Extensions.AspNetCore.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
 	  <FrameworkReference Include="Microsoft.AspNetCore.App" />
-	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspectCore.Extensions.AspNetCore/AspectCore.Extensions.AspNetCore.csproj
+++ b/src/AspectCore.Extensions.AspNetCore/AspectCore.Extensions.AspNetCore.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Extensions.AspectScope/AspectCore.Extensions.AspectScope.csproj
+++ b/src/AspectCore.Extensions.AspectScope/AspectCore.Extensions.AspectScope.csproj
@@ -10,7 +10,7 @@
     <Title>AspectCore.Extensions.AspectScope</Title>
     <PackageTags>DynamicProxy;Aop;Aspect;AspectCore;Intercepter</PackageTags>
     <PackageReleaseNotes>ScopedContext extension system for AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Extensions.AspectScope/AspectCore.Extensions.AspectScope.csproj
+++ b/src/AspectCore.Extensions.AspectScope/AspectCore.Extensions.AspectScope.csproj
@@ -10,14 +10,14 @@
     <Title>AspectCore.Extensions.AspectScope</Title>
     <PackageTags>DynamicProxy;Aop;Aspect;AspectCore;Intercepter</PackageTags>
     <PackageReleaseNotes>ScopedContext extension system for AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspectCore.Extensions.Autofac/AspectCore.Extensions.Autofac.csproj
+++ b/src/AspectCore.Extensions.Autofac/AspectCore.Extensions.Autofac.csproj
@@ -9,7 +9,7 @@
     <PackageId>AspectCore.Extensions.Autofac</PackageId>
     <PackageTags>DynamicProxy;Aop;Autofac;AspectCore</PackageTags>
     <PackageReleaseNotes>Interceptor and dynamicProxy support for Autofac via AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Extensions.Autofac/AspectCore.Extensions.Autofac.csproj
+++ b/src/AspectCore.Extensions.Autofac/AspectCore.Extensions.Autofac.csproj
@@ -9,14 +9,14 @@
     <PackageId>AspectCore.Extensions.Autofac</PackageId>
     <PackageTags>DynamicProxy;Aop;Autofac;AspectCore</PackageTags>
     <PackageReleaseNotes>Interceptor and dynamicProxy support for Autofac via AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 

--- a/src/AspectCore.Extensions.Configuration/AspectCore.Extensions.Configuration.csproj
+++ b/src/AspectCore.Extensions.Configuration/AspectCore.Extensions.Configuration.csproj
@@ -8,7 +8,7 @@
 		<PackageId>AspectCore.Extensions.Configuration</PackageId>
 		<PackageTags>Reflection;Aop;DynamicProxy;Configuration</PackageTags>
 		<PackageReleaseNotes>Configuration extension system for ASP.NET Core via AspectCore-Framework.</PackageReleaseNotes>
-		<TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
 
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<IncludeSymbols>true</IncludeSymbols>
@@ -33,6 +33,11 @@
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/AspectCore.Extensions.Configuration/AspectCore.Extensions.Configuration.csproj
+++ b/src/AspectCore.Extensions.Configuration/AspectCore.Extensions.Configuration.csproj
@@ -8,12 +8,17 @@
 		<PackageId>AspectCore.Extensions.Configuration</PackageId>
 		<PackageTags>Reflection;Aop;DynamicProxy;Configuration</PackageTags>
 		<PackageReleaseNotes>Configuration extension system for ASP.NET Core via AspectCore-Framework.</PackageReleaseNotes>
-		<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
 
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' ">
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
+	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
@@ -31,7 +36,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/AspectCore.Extensions.DataAnnotations/AspectCore.Extensions.DataAnnotations.csproj
+++ b/src/AspectCore.Extensions.DataAnnotations/AspectCore.Extensions.DataAnnotations.csproj
@@ -9,14 +9,14 @@
     <PackageId>AspectCore.Extensions.DataAnnotations</PackageId>
     <PackageTags>DataValidation;DataAnnotations;AspectCore;AOP</PackageTags>
     <PackageReleaseNotes>DataAnnotations extension system for AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 

--- a/src/AspectCore.Extensions.DataAnnotations/AspectCore.Extensions.DataAnnotations.csproj
+++ b/src/AspectCore.Extensions.DataAnnotations/AspectCore.Extensions.DataAnnotations.csproj
@@ -9,7 +9,7 @@
     <PackageId>AspectCore.Extensions.DataAnnotations</PackageId>
     <PackageTags>DataValidation;DataAnnotations;AspectCore;AOP</PackageTags>
     <PackageReleaseNotes>DataAnnotations extension system for AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Extensions.DataValidation/AspectCore.Extensions.DataValidation.csproj
+++ b/src/AspectCore.Extensions.DataValidation/AspectCore.Extensions.DataValidation.csproj
@@ -9,7 +9,7 @@
     <PackageId>AspectCore.Extensions.DataValidation</PackageId>
     <PackageTags>DataValidation;AspectCore;AOP</PackageTags>
     <PackageReleaseNotes>DataValidation extension system for AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Extensions.DataValidation/AspectCore.Extensions.DataValidation.csproj
+++ b/src/AspectCore.Extensions.DataValidation/AspectCore.Extensions.DataValidation.csproj
@@ -9,14 +9,14 @@
     <PackageId>AspectCore.Extensions.DataValidation</PackageId>
     <PackageTags>DataValidation;AspectCore;AOP</PackageTags>
     <PackageReleaseNotes>DataValidation extension system for AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 

--- a/src/AspectCore.Extensions.DependencyInjection/AspectCore.Extensions.DependencyInjection.csproj
+++ b/src/AspectCore.Extensions.DependencyInjection/AspectCore.Extensions.DependencyInjection.csproj
@@ -1,39 +1,42 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\build\common.props" />
-  
-  <PropertyGroup>
-    <Description>Interceptor and dynamicProxy support for Microsoft.Extensions.DependencyInjection via AspectCore Framework.</Description>
-    <AssemblyTitle>AspectCore.Extensions.DependencyInjection</AssemblyTitle>
-    <AssemblyName>AspectCore.Extensions.DependencyInjection</AssemblyName>
-    <PackageId>AspectCore.Extensions.DependencyInjection</PackageId>
-    <PackageTags>DynamicProxy;Aop;DependencyInjection;AspectCore</PackageTags>
-    <PackageReleaseNotes>Interceptor and dynamicProxy support for Microsoft.Extensions.DependencyInjection via AspectCore Framework.</PackageReleaseNotes>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
+	<Import Project="..\..\build\common.props" />
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-  </ItemGroup>
-
+	<PropertyGroup>
+		<Description>Interceptor and dynamicProxy support for Microsoft.Extensions.DependencyInjection via AspectCore Framework.</Description>
+		<AssemblyTitle>AspectCore.Extensions.DependencyInjection</AssemblyTitle>
+		<AssemblyName>AspectCore.Extensions.DependencyInjection</AssemblyName>
+		<PackageId>AspectCore.Extensions.DependencyInjection</PackageId>
+		<PackageTags>DynamicProxy;Aop;DependencyInjection;AspectCore</PackageTags>
+		<PackageReleaseNotes>Interceptor and dynamicProxy support for Microsoft.Extensions.DependencyInjection via AspectCore Framework.</PackageReleaseNotes>
+		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+		<TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	</PropertyGroup>
 
 	<ItemGroup>
-    <ProjectReference Include="..\AspectCore.Core\AspectCore.Core.csproj" />
-  </ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\AspectCore.Core\AspectCore.Core.csproj" />
+	</ItemGroup>
 </Project>

--- a/src/AspectCore.Extensions.DependencyInjection/AspectCore.Extensions.DependencyInjection.csproj
+++ b/src/AspectCore.Extensions.DependencyInjection/AspectCore.Extensions.DependencyInjection.csproj
@@ -10,7 +10,7 @@
 		<PackageTags>DynamicProxy;Aop;DependencyInjection;AspectCore</PackageTags>
 		<PackageReleaseNotes>Interceptor and dynamicProxy support for Microsoft.Extensions.DependencyInjection via AspectCore Framework.</PackageReleaseNotes>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-		<TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -34,6 +34,10 @@
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/AspectCore.Extensions.Hosting/AspectCore.Extensions.Hosting.csproj
+++ b/src/AspectCore.Extensions.Hosting/AspectCore.Extensions.Hosting.csproj
@@ -1,14 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' ">
+	  <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">

--- a/src/AspectCore.Extensions.Hosting/AspectCore.Extensions.Hosting.csproj
+++ b/src/AspectCore.Extensions.Hosting/AspectCore.Extensions.Hosting.csproj
@@ -1,35 +1,41 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\build\common.props" />
-  <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
+	<Import Project="..\..\build\common.props" />
+	<PropertyGroup>
+		<TargetFrameworks>net9.0;net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+	</ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' ">
-	  <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-  </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' ">
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+	</ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-	  <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-  </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+	</ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-	  <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
-  </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+	</ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-	  <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-  </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\AspectCore.Abstractions\AspectCore.Abstractions.csproj" />
-    <ProjectReference Include="..\AspectCore.Core\AspectCore.Core.csproj" />
-    <ProjectReference Include="..\AspectCore.Extensions.DependencyInjection\AspectCore.Extensions.DependencyInjection.csproj" />
-  </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+	</ItemGroup>
+
+
+	<ItemGroup>
+		<ProjectReference Include="..\AspectCore.Abstractions\AspectCore.Abstractions.csproj" />
+		<ProjectReference Include="..\AspectCore.Core\AspectCore.Core.csproj" />
+		<ProjectReference
+			Include="..\AspectCore.Extensions.DependencyInjection\AspectCore.Extensions.DependencyInjection.csproj" />
+	</ItemGroup>
 </Project>

--- a/src/AspectCore.Extensions.LightInject/AspectCore.Extensions.LightInject.csproj
+++ b/src/AspectCore.Extensions.LightInject/AspectCore.Extensions.LightInject.csproj
@@ -7,14 +7,14 @@
     <PackageTags>DynamicProxy;Aop;LightInject;AspectCore</PackageTags>
     <PackageReleaseNotes>Interceptor and dynamicProxy support for LightInject via AspectCore Framework.</PackageReleaseNotes>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>	
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspectCore.Extensions.LightInject/AspectCore.Extensions.LightInject.csproj
+++ b/src/AspectCore.Extensions.LightInject/AspectCore.Extensions.LightInject.csproj
@@ -7,7 +7,7 @@
     <PackageTags>DynamicProxy;Aop;LightInject;AspectCore</PackageTags>
     <PackageReleaseNotes>Interceptor and dynamicProxy support for LightInject via AspectCore Framework.</PackageReleaseNotes>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>	
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Extensions.Reflection/AspectCore.Extensions.Reflection.csproj
+++ b/src/AspectCore.Extensions.Reflection/AspectCore.Extensions.Reflection.csproj
@@ -1,21 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\build\common.props" />
-  <PropertyGroup>
-    <Description>Reflection extension system for AspectCore Framework.</Description>
-    <AssemblyTitle>AspectCore.Extensions.Reflection</AssemblyTitle>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
-    <AssemblyName>AspectCore.Extensions.Reflection</AssemblyName>
-    <PackageId>AspectCore.Extensions.Reflection</PackageId>
-    <PackageTags>Reflection;Aop;DynamicProxy</PackageTags>
-    <PackageReleaseNotes>Reflection extension system for AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
+	<Import Project="..\..\build\common.props" />
+	<PropertyGroup>
+		<Description>Reflection extension system for AspectCore Framework.</Description>
+		<AssemblyTitle>AspectCore.Extensions.Reflection</AssemblyTitle>
+		<AllowUnsafeBlocks>False</AllowUnsafeBlocks>
+		<AssemblyName>AspectCore.Extensions.Reflection</AssemblyName>
+		<PackageId>AspectCore.Extensions.Reflection</PackageId>
+		<PackageTags>Reflection;Aop;DynamicProxy</PackageTags>
+		<PackageReleaseNotes>Reflection extension system for AspectCore Framework.</PackageReleaseNotes>
+		<TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
-	
+	<ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
+		<PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
+		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
+	</ItemGroup>
+
+
 </Project>

--- a/src/AspectCore.Extensions.Reflection/AspectCore.Extensions.Reflection.csproj
+++ b/src/AspectCore.Extensions.Reflection/AspectCore.Extensions.Reflection.csproj
@@ -8,7 +8,7 @@
 		<PackageId>AspectCore.Extensions.Reflection</PackageId>
 		<PackageTags>Reflection;Aop;DynamicProxy</PackageTags>
 		<PackageReleaseNotes>Reflection extension system for AspectCore Framework.</PackageReleaseNotes>
-		<TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AspectCore.Extensions.Reflection/Extensions/TypeExtensions.cs
+++ b/src/AspectCore.Extensions.Reflection/Extensions/TypeExtensions.cs
@@ -189,8 +189,12 @@ namespace AspectCore.Extensions.Reflection
             {
                 throw new ArgumentNullException(nameof(type));
             }
-            return type.IsGenericType && typeof(ITuple).IsAssignableFrom(type.GetTypeInfo().GetGenericTypeDefinition());
 
+#if NETSTANDARD2_0
+            return false;
+#else
+            return type.IsGenericType && typeof(ITuple).IsAssignableFrom(type.GetTypeInfo().GetGenericTypeDefinition());
+#endif
         }
     }
 }

--- a/src/AspectCore.Extensions.Windsor/AspectCore.Extensions.Windsor.csproj
+++ b/src/AspectCore.Extensions.Windsor/AspectCore.Extensions.Windsor.csproj
@@ -9,14 +9,14 @@
     <PackageId>AspectCore.Extensions.Windsor</PackageId>
     <PackageTags>DynamicProxy;Aop;Windsor;AspectCore</PackageTags>
     <PackageReleaseNotes>Interceptor and dynamicProxy support for Castle.Windsor via AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 

--- a/src/AspectCore.Extensions.Windsor/AspectCore.Extensions.Windsor.csproj
+++ b/src/AspectCore.Extensions.Windsor/AspectCore.Extensions.Windsor.csproj
@@ -9,7 +9,7 @@
     <PackageId>AspectCore.Extensions.Windsor</PackageId>
     <PackageTags>DynamicProxy;Aop;Windsor;AspectCore</PackageTags>
     <PackageReleaseNotes>Interceptor and dynamicProxy support for Castle.Windsor via AspectCore Framework.</PackageReleaseNotes>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/tests/AspectCore.Extensions.Autofac.Test/AspectCore.Extensions.Autofac.Test.csproj
+++ b/tests/AspectCore.Extensions.Autofac.Test/AspectCore.Extensions.Autofac.Test.csproj
@@ -33,13 +33,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-		<PackageReference Include="xunit" Version="2.7.0" />
+		<PackageReference Include="xunit" Version="2.9.2" />
 	</ItemGroup>
 
 </Project>

--- a/tests/AspectCore.Extensions.Autofac.Test/AspectCore.Extensions.Autofac.Test.csproj
+++ b/tests/AspectCore.Extensions.Autofac.Test/AspectCore.Extensions.Autofac.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
 		<DebugType>portable</DebugType>
 		<AssemblyName>AspectCore.Extensions.Autofac.Test</AssemblyName>
 		<PackageId>AspectCore.Extensions.Autofac.Test</PackageId>
@@ -30,6 +30,11 @@
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
 		<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="8.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+		<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="9.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/AspectCore.Extensions.Configuration.Tests/AspectCore.Extensions.Configuration.Tests.csproj
+++ b/tests/AspectCore.Extensions.Configuration.Tests/AspectCore.Extensions.Configuration.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
@@ -18,6 +18,11 @@
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/AspectCore.Extensions.Configuration.Tests/AspectCore.Extensions.Configuration.Tests.csproj
+++ b/tests/AspectCore.Extensions.Configuration.Tests/AspectCore.Extensions.Configuration.Tests.csproj
@@ -21,9 +21,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-		<PackageReference Include="xunit" Version="2.7.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="xunit" Version="2.9.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/tests/AspectCore.Extensions.DependencyInjection.Test/AspectCore.Extensions.DependencyInjection.Test.csproj
+++ b/tests/AspectCore.Extensions.DependencyInjection.Test/AspectCore.Extensions.DependencyInjection.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net7.0;net6.0</TargetFrameworks>
 		<DebugType>portable</DebugType>
 		<AssemblyName>AspectCore.Extensions.DependencyInjection.Test</AssemblyName>
 		<PackageId>AspectCore.Extensions.DependencyInjection.Test</PackageId>
@@ -25,6 +25,10 @@
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="8.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="9.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/AspectCore.Extensions.DependencyInjection.Test/AspectCore.Extensions.DependencyInjection.Test.csproj
+++ b/tests/AspectCore.Extensions.DependencyInjection.Test/AspectCore.Extensions.DependencyInjection.Test.csproj
@@ -28,13 +28,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-		<PackageReference Include="xunit" Version="2.7.0" />
+		<PackageReference Include="xunit" Version="2.9.2" />
 		<PackageReference Include="System.Reflection" Version="4.3.0" />
 		<PackageReference Include="System.Linq" Version="4.3.0" />
 	</ItemGroup>

--- a/tests/AspectCore.Extensions.DependencyInjection.Test/Issues/ConstructorSelectTests.cs
+++ b/tests/AspectCore.Extensions.DependencyInjection.Test/Issues/ConstructorSelectTests.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Text;
+using System.Threading.Tasks;
+using AspectCore.Configuration;
+using AspectCore.DynamicProxy;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AspectCore.Extensions.DependencyInjection.Test.Issues
+{
+    //https://github.com/dotnetcore/AspectCore-Framework/issues/313
+    public class ConstructorSelectTests
+    {
+        public interface IInteriorService
+        {
+            string SayHello();
+        }
+        public interface IExternalService
+        {
+            string SayHello();
+        }
+
+        public class InteriorServiceImpl : IInteriorService
+        {
+            [CustomInterceptor]
+            public string SayHello() => "Hello Interior!";
+        }
+        public class ExternalServiceImpl : IExternalService
+        {
+            private StringBuilder output = new StringBuilder();
+            private readonly IInteriorService? _service1;
+
+            public ExternalServiceImpl(IInteriorService service1) : this()
+            {
+                _service1 = service1;
+                output.AppendLine("ExternalServiceImpl(IParentService)");
+            }
+            public ExternalServiceImpl()
+            {
+                output.AppendLine("ExternalServiceImpl()");
+            }
+
+            [CustomInterceptor]
+            public string SayHello()
+            {
+                output.AppendLine("Hello External!");
+                output.AppendLine(_service1?.SayHello());
+                return output.ToString();
+            }
+        }
+
+        public class CustomInterceptor : AbstractInterceptorAttribute
+    {
+        public override async Task Invoke(AspectContext context, AspectDelegate next) => await context.Invoke(next);
+    }
+
+        [Fact]
+        public void ConstructorSelectWithInterceptor_Test()
+        {
+            IServiceCollection services = new ServiceCollection();
+            services.AddTransient<IInteriorService, InteriorServiceImpl>();
+            services.AddTransient<IExternalService, ExternalServiceImpl>();
+            services.ConfigureDynamicProxy(option =>
+            {
+                option.Interceptors.AddTyped<CustomInterceptor>();
+            });
+            IServiceProvider serviceProvider = services.BuildDynamicProxyProvider();
+            IExternalService service2 = serviceProvider.GetRequiredService<IExternalService>();
+            string output = service2.SayHello();
+            
+        }
+    }
+}

--- a/tests/AspectCore.Extensions.Hosting.Tests/AspectCore.Extensions.Hosting.Tests.csproj
+++ b/tests/AspectCore.Extensions.Hosting.Tests/AspectCore.Extensions.Hosting.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/AspectCore.Extensions.Hosting.Tests/AspectCore.Extensions.Hosting.Tests.csproj
+++ b/tests/AspectCore.Extensions.Hosting.Tests/AspectCore.Extensions.Hosting.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
 	  <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/AspectCore.Extensions.LightInject.Test/AspectCore.Extensions.LightInject.Test.csproj
+++ b/tests/AspectCore.Extensions.LightInject.Test/AspectCore.Extensions.LightInject.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/tests/AspectCore.Extensions.LightInject.Test/AspectCore.Extensions.LightInject.Test.csproj
+++ b/tests/AspectCore.Extensions.LightInject.Test/AspectCore.Extensions.LightInject.Test.csproj
@@ -11,12 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AspectCore.Extensions.Reflection.Test/AspectCore.Extensions.Reflection.Test.csproj
+++ b/tests/AspectCore.Extensions.Reflection.Test/AspectCore.Extensions.Reflection.Test.csproj
@@ -22,14 +22,14 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AspectCore.Extensions.Reflection.Test/AspectCore.Extensions.Reflection.Test.csproj
+++ b/tests/AspectCore.Extensions.Reflection.Test/AspectCore.Extensions.Reflection.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>AspectCore.Extensions.Reflection.Test</AssemblyName>
     <PackageId>AspectCore.Extensions.Reflection.Test</PackageId>
@@ -14,12 +14,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\AspectCore.Extensions.Reflection\AspectCore.Extensions.Reflection.csproj" />
   </ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-		<PackageReference Include="System.Reflection" Version="4.3.0" />
-		<PackageReference Include="System.Linq" Version="4.3.0" />
-		<PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-	</ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/tests/AspectCore.Extensions.Windsor.Test/AspectCore.Extensions.Windsor.Test.csproj
+++ b/tests/AspectCore.Extensions.Windsor.Test/AspectCore.Extensions.Windsor.Test.csproj
@@ -19,9 +19,9 @@
 	</ItemGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/AspectCore.Extensions.Windsor.Test/AspectCore.Extensions.Windsor.Test.csproj
+++ b/tests/AspectCore.Extensions.Windsor.Test/AspectCore.Extensions.Windsor.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
 	  <IsPackable>false</IsPackable>
 	  <RootNamespace>AspectCoreTest.Windsor</RootNamespace>
   </PropertyGroup>
@@ -18,7 +18,11 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="8.0.0" />
 	</ItemGroup>
 
-  <ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="9.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
 	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/tests/AspectCore.Tests/AspectCore.Tests.csproj
+++ b/tests/AspectCore.Tests/AspectCore.Tests.csproj
@@ -17,9 +17,9 @@
 	</ItemGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/AspectCore.Tests/AspectCore.Tests.csproj
+++ b/tests/AspectCore.Tests/AspectCore.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -14,6 +14,10 @@
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
 		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="9.0.0" />
 	</ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#318 调整
恢复netstandard2.1;netstandard2.0构建目标支持
根据MS文档：
netstandard2.0目标以支持.NET Framework
对于netstandard2.1;netstandard2.0目标，部分MS包依赖与.NET6保持一致

添加.net9构建目标