### PR TITLE
use interface's default implementation when creating proxy type

### DIFF
--- a/src/AspectCore.Core/Utils/ProxyGeneratorUtils.cs
+++ b/src/AspectCore.Core/Utils/ProxyGeneratorUtils.cs
@@ -375,6 +375,10 @@ namespace AspectCore.Utils
 
             internal static MethodBuilder DefineInterfaceImplMethod(MethodInfo method, TypeBuilder implTypeBuilder)
             {
+                // method is not abstract means it is a default implementation on the interface, so don't need to define method on the proxy type.
+                if (method.IsAbstract == false)
+                    return null;
+
                 var methodBuilder = implTypeBuilder.DefineMethod(method.Name, InterfaceMethodAttributes, method.CallingConvention, method.ReturnType, method.GetParameterTypes());
                 var ilGen = methodBuilder.GetILGenerator();
                 if (method.ReturnType != typeof(void))

--- a/tests/AspectCore.Tests/Issues/DynamicProxy/InterfaceDefaultMethodsShouldBeUsedTests.cs
+++ b/tests/AspectCore.Tests/Issues/DynamicProxy/InterfaceDefaultMethodsShouldBeUsedTests.cs
@@ -1,0 +1,24 @@
+﻿using AspectCore.DynamicProxy;
+using AspectCore.Tests.DynamicProxy;
+using Xunit;
+
+namespace AspectCore.Tests.Issues.DynamicProxy;
+
+// https://github.com/dotnetcore/AspectCore-Framework/issues/223
+public class InterfaceDefaultMethodsShouldBeUsedTests : DynamicProxyTestBase
+{
+    public interface IService
+    {
+        int Get() => 1;
+    }
+
+    public class Service : IService{}
+
+    [Fact]
+    public void CreateInterfaceProxy_WithoutImplementationType_Test()
+    {
+        var service = ProxyGenerator.CreateInterfaceProxy<IService>();
+        var result = service.Get();
+        Assert.Equal(1, result);
+    }
+}


### PR DESCRIPTION
- use interface's default implementation when creating proxy type
- see details: https://github.com/dotnetcore/AspectCore-Framework/issues/223