### PR TITLE
Fix service scope validation compatibility with Microsoft DI

### DIFF
--- a/.github/workflows/build-pr-ci.yml
+++ b/.github/workflows/build-pr-ci.yml
@@ -12,8 +12,12 @@ jobs:
         fetch-depth: 0
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
-      with: # NOTE: we don't need to install 6.x, 8.x and 9.x cause they are included in windows-latest(windows-2022) image.
-        dotnet-version: 7.x
+      with: # Install all required versions explicitly, since some frameworks may be missing from the image if they have been removed due to end of support.
+        dotnet-version: | 
+          6.0.x
+          7.0.x
+          8.0.x
+          9.0.x
         
     - name: Build Reason
       run: "echo ref: ${{github.ref}} event: ${{github.event_name}}"

--- a/src/AspectCore.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/AspectCore.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -53,10 +53,10 @@ namespace AspectCore.Extensions.DependencyInjection
             services.TryAddScoped<IAspectActivatorFactory, AspectActivatorFactory>();
             services.TryAddScoped<IProxyGenerator, ProxyGenerator>();
             services.TryAddScoped<IParameterInterceptorSelector, ParameterInterceptorSelector>();
+            services.TryAddScoped<IInterceptorCollector, InterceptorCollector>();
+            services.TryAddScoped<IAspectBuilderFactory, AspectBuilderFactory>();
 
-            services.TryAddSingleton<IInterceptorCollector, InterceptorCollector>();
             services.TryAddSingleton<IAspectValidatorBuilder, AspectValidatorBuilder>();
-            services.TryAddSingleton<IAspectBuilderFactory, AspectBuilderFactory>();
             services.TryAddSingleton<IProxyTypeGenerator, ProxyTypeGenerator>();
             services.TryAddSingleton<IAspectCachingProvider, AspectCachingProvider>();
 

--- a/tests/AspectCore.Extensions.DependencyInjection.Test/ServiceCollectionBuildExtensionsTests.cs
+++ b/tests/AspectCore.Extensions.DependencyInjection.Test/ServiceCollectionBuildExtensionsTests.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AspectCore.Extensions.DependencyInjection.Test;
+
+public class ServiceCollectionBuildExtensionsTests
+{
+    [Fact]
+    public void BuildDynamicProxyProvider_Validate()
+    {
+        var services = new ServiceCollection();
+        var provider = services.BuildDynamicProxyProvider(new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
+        Assert.NotNull(provider);
+    }
+}


### PR DESCRIPTION
## Description

This PR addresses an issue where certain services registered in **AspectCore.Extensions.DependencyInjection** were failing Microsoft Dependency Injection’s validation of service scopes. The fix aligns how scoped/transient services are handled so that registrations pass MS.DI’s scope validation.

## Changes

- Adjusted the scope lifetime for some services/registrations so that they comply with MS.DI’s rules.  
- Added a test verifying that scope validation passes under Microsoft DI.
- Install all required dotnet versions explicitly (dotnet 6.0 has been remove from the image).
