### PR TITLE
Fix #297: Remove invalid Tars.Net link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Core support for aspect-interceptor, dependency injection integration, web appli
 * [shriek-fx](https://github.com/ElderJames/shriek-fx)   
 * [Util](https://github.com/dotnetcore/Util)
 * [Zxw.Framework.NetCore](https://github.com/VictorTzeng/Zxw.Framework.NetCore)
-* [Tars.Net](https://github.com/TarsNET)
 * [FastCache](https://github.com/sj-distributor/FastCache)
 
 ## Contributors


### PR DESCRIPTION
Fixes #297

The Tars.Net link (https://github.com/TarsNET) returns 404. After investigation:

- The original TarsNET organization no longer exists
- The old Tars.Csharp repo (fs7744/Tars.Csharp) was abandoned
- No active .NET Tars repository found under TarsCloud organization

Removing the invalid link to prevent dead link in documentation.